### PR TITLE
Support upgrading between deb packages

### DIFF
--- a/ansible/roles/install-grsec-kernel/tasks/grub_config.yml
+++ b/ansible/roles/install-grsec-kernel/tasks/grub_config.yml
@@ -18,12 +18,19 @@
   set_fact:
     grub_grsecurity_menu_entry: "{{ item }}"
   with_items: grub_menu_options
-  when: "{{ item.name | match('.*-grsec$') }}"
+  # Check for an exact match, right-aligned, for the target kernel version
+  # currently being installed. Tested on Debian. Example string to match:
+  #   Debian GNU/Linux, with Linux 3.14.54-grsec
+  # Example string NOT to match:
+  #   Debian GNU/Linux, with Linux 3.14.54-grsec (recovery mode)
+  when: "{{ item.name | match('.*'+grsecurity_desired_kernel_version+'$') }}"
 
 - name: Ensure grsecurity kernel menu entry is populated.
   fail:
     msg: >
-      Could not find GRUB menu entry for grsecurity kernel.
+      Could not find GRUB menu entry for grsecurity kernel {{ grsecurity_desired_kernel_version }}.
+      Try installing manually via `dpkg -i <package_name>` and verifying the menu
+      entry exists in the GRUB config file.
   when: grub_grsecurity_menu_entry is not defined
 
 - name: Set grsecurity kernel as default option in GRUB config.

--- a/ansible/roles/install-grsec-kernel/tasks/main.yml
+++ b/ansible/roles/install-grsec-kernel/tasks/main.yml
@@ -1,5 +1,6 @@
 ---
 - include: set_host_facts.yml
+
 - include: packages.yml
 
 - include: disable_python_memprotect.yml
@@ -9,40 +10,6 @@
 
 - include: grub_config.yml
 
-- name: Reboot into the grsecurity kernel.
-  # Simply rebooting causes the subsequent wait_for task to fail. See here:
-  # https://github.com/ansible/ansible/issues/10616
-  # Sleeping and then shutting down, via the shell module, is a workaround.
-  shell: sleep 3 && shutdown -r now "Rebooting into the grsec kernel..."
-  async: 1
-  poll: 0
-  ignore_errors: true
-  sudo: yes
-  when: "'grsec' not in ansible_kernel"
+- include: validate_install.yml
+  when: grsecurity_desired_kernel_version != ansible_kernel
 
-- name: Wait for server to come back.
-  local_action: wait_for
-    host={{ ansible_ssh_host }}
-    port={{ ansible_ssh_port | default('22')}}
-    delay=30
-    state=started
-  sudo: false
-  when: "'grsec' not in ansible_kernel"
-
-  # Adding extra wait time to prevent timeouts
-  # during debugging. Likely not necessary, but test
-  # before removing.
-- name: Wait extra time for server to come back up.
-  pause:
-    seconds: 30
-  when: "'grsec' not in ansible_kernel"
-
-- name: Refresh host facts.
-  action: setup
-
-- name: Fail if grsecurity kernel not running.
-  fail:
-    msg: >
-      Grsecurity kernel is not running. Instead, found
-      kernel {{ ansible_kernel }}.
-  when: "'grsec' not in ansible_kernel"

--- a/ansible/roles/install-grsec-kernel/tasks/packages.yml
+++ b/ansible/roles/install-grsec-kernel/tasks/packages.yml
@@ -12,7 +12,7 @@
   copy:
     src: "{{ grsecurity_deb_package }}"
     dest: "/root/{{ grsecurity_deb_package | basename }}"
-  when: "'grsec' not in ansible_kernel"
+  when: grsecurity_desired_kernel_version != ansible_kernel
 
 - name: Install PaX utilities.
   apt:
@@ -29,7 +29,7 @@
     # about overwriting lib modules. A subsequent task will validate
     # that a grsec-patched kernel is actually running.
     dpkg_options: skip-same-version,force-confdef,force-confold
-  when: "'grsec' not in ansible_kernel"
+  when: grsecurity_desired_kernel_version != ansible_kernel
   notify:
     - Update GRUB.
     - Update host facts.

--- a/ansible/roles/install-grsec-kernel/tasks/packages.yml
+++ b/ansible/roles/install-grsec-kernel/tasks/packages.yml
@@ -1,13 +1,4 @@
 ---
-- name: Check filename for deb package.
-  fail:
-    msg: >
-      No deb package specified for installation.
-      Define the variable 'grsecurity_deb_package'
-      with the filepath to the local .deb package,
-      then rerun the playbook.
-  when: grsecurity_deb_package is not defined
-
 - name: Copy kernel image deb package.
   copy:
     src: "{{ grsecurity_deb_package }}"

--- a/ansible/roles/install-grsec-kernel/tasks/set_host_facts.yml
+++ b/ansible/roles/install-grsec-kernel/tasks/set_host_facts.yml
@@ -2,3 +2,6 @@
 - name: Get GRUB menu options as host facts.
   action: grub_menu_options
 
+- name: Set desired kernel version as host fact.
+  set_fact: grsecurity_desired_kernel_version="{{ grsecurity_deb_package | basename | regex_replace('^linux-image-([\d\.]+-grsec)_.*$', '\\1') }}"
+

--- a/ansible/roles/install-grsec-kernel/tasks/set_host_facts.yml
+++ b/ansible/roles/install-grsec-kernel/tasks/set_host_facts.yml
@@ -2,6 +2,16 @@
 - name: Get GRUB menu options as host facts.
   action: grub_menu_options
 
+  # Role requires that `grsecurity_deb_package` be defined.
+- name: Check filename for deb package.
+  fail:
+    msg: >
+      No deb package specified for installation.
+      Define the variable 'grsecurity_deb_package'
+      with the filepath to the local .deb package,
+      then rerun the playbook.
+  when: grsecurity_deb_package is not defined
+
 - name: Set desired kernel version as host fact.
   set_fact: grsecurity_desired_kernel_version="{{ grsecurity_deb_package | basename | regex_replace('^linux-image-([\d\.]+-grsec)_.*$', '\\1') }}"
 

--- a/ansible/roles/install-grsec-kernel/tasks/validate_install.yml
+++ b/ansible/roles/install-grsec-kernel/tasks/validate_install.yml
@@ -1,0 +1,38 @@
+---
+- name: Reboot into the grsecurity kernel.
+  # Simply rebooting causes the subsequent wait_for task to fail. See here:
+  # https://github.com/ansible/ansible/issues/10616
+  # Sleeping and then shutting down, via the shell module, is a workaround.
+  shell: sleep 3 && shutdown -r now "Rebooting into the grsec kernel..."
+  async: 1
+  poll: 0
+  ignore_errors: true
+  sudo: yes
+
+- name: Wait for server to come back.
+  local_action: wait_for
+    host={{ ansible_ssh_host }}
+    port={{ ansible_ssh_port | default('22')}}
+    delay=30
+    state=started
+  sudo: false
+
+  # Adding extra wait time to prevent timeouts
+  # during debugging. Likely not necessary, but test
+  # before removing.
+- name: Wait extra time for server to come back up.
+  pause:
+    seconds: 30
+
+  # Running the setup module will refresh the `ansible_kernel` host fact
+  # with the current value. The `grsecurity_desired_kernel_version` host fact
+  # persists from when it was set earlier in the role.
+- name: Refresh host facts.
+  action: setup
+
+- name: Fail if grsecurity kernel not running.
+  fail:
+    msg: >
+      Grsecurity kernel is not running. Expected to find
+      {{ grsecurity_desired_kernel_version }}. Instead, found
+      kernel {{ ansible_kernel }}.


### PR DESCRIPTION
The install role now intelligently handles upgrades from one grsecurity-patched kernel deb package to another. Updated the the GRUB menu entry logic to search for a specific kernel version and ensure that the output of `uname -r` matches the kernel version provided by the deb file.
