### PR TITLE
Fix use of vagrant

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,8 +12,8 @@ Vagrant.configure("2") do |config|
       # The stable playbook will prompt for HTTP auth credentials prior to running.
       # One subsequent runs of the stable playbook, you can simply hit enter to skip
       # the credential entry, since the files have already been downloaded.
-      ansible.playbook = 'ansible/build-grsecurity-kernel-test.yml'
-      ansible.playbook = 'ansible/build-grsecurity-kernel-stable.yml'
+      ansible.playbook = 'examples/build-grsecurity-kernel-test.yml'
+      ansible.playbook = 'examples/build-grsecurity-kernel-stable.yml'
       ansible.verbose = 'vv'
       # Exposing the build strategy var for testing various build strategies quickly.
       ansible.extra_vars = {

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,8 +12,8 @@ Vagrant.configure("2") do |config|
       # The stable playbook will prompt for HTTP auth credentials prior to running.
       # One subsequent runs of the stable playbook, you can simply hit enter to skip
       # the credential entry, since the files have already been downloaded.
-      ansible.playbook = 'examples/build-grsecurity-kernel-test.yml'
       ansible.playbook = 'examples/build-grsecurity-kernel-stable.yml'
+      ansible.playbook = 'examples/build-grsecurity-kernel-test.yml'
       ansible.verbose = 'vv'
       # Exposing the build strategy var for testing various build strategies quickly.
       ansible.extra_vars = {

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,2 @@
+[defaults]
+roles_path = roles


### PR DESCRIPTION
An oversight in #26 caused the vagrant VMs to fail by not finding the playbooks at their new location, in `examples/`. This PR fixes the filepaths and adds an `ansible.cfg` to point to the `roles_path`.

This PR **also changes the default playbook to use the `test` patches**, when it was previously `stable`. To compile with the `stable` grsecurity patches, simply swap the order of playbooks inside the Vagrantfile prior to running `vagrant provision`.
