### PR TITLE
Remove unused static vars from build role

### DIFF
--- a/roles/build-grsec-kernel/defaults/main.yml
+++ b/roles/build-grsec-kernel/defaults/main.yml
@@ -35,28 +35,7 @@ include_ubuntu_overlay: false
 
 download_directory: /usr/local/src
 
-# The version of the Linux kernel is modified
-# dynamically according to `grsecurity_patch_type`.
-# The test patches for grsecurity apply to the 4.x kernels,
-# and the stable patches work with 3.14.x.
-linux_kernel_version: 3.14.57
-linux_base_url: "https://www.kernel.org/pub/linux/kernel/v{{ linux_kernel_version.split('.') | first }}.x/"
-
-linux_tarball:
-  {
-    filename: "linux-{{ linux_kernel_version }}.tar.xz",
-    url: "{{ linux_base_url }}/linux-{{ linux_kernel_version }}.tar.xz",
-  }
-
-linux_tarball_signature:
-  {
-    filename: "linux-{{ linux_kernel_version }}.tar.sign",
-    url: "{{ linux_base_url }}/linux-{{ linux_kernel_version }}.tar.sign",
-  }
-
-linux_checksums_url: "{{ linux_base_url }}/sha256sums.asc"
 linux_source_directory: "{{ download_directory }}/linux-{{ linux_kernel_version }}"
-
 gpg_keyserver: hkps.pool.sks-keyservers.net
 
 # Assumes 64-bit (not reading machine architecture dynamically.)

--- a/roles/build-grsec-kernel/library/grsecurity_urls.py
+++ b/roles/build-grsec-kernel/library/grsecurity_urls.py
@@ -67,9 +67,10 @@ class LinuxKernelURLs():
             linux_tarball_url=self.linux_tarball_url,
             )
 
+
     @property
     def linux_base_url(self):
-        return urljoin(LINUX_KERNEL_BASE_URL, "v{}.x".format(self.linux_major_version))
+        return urljoin(LINUX_KERNEL_BASE_URL, "v{}.x/".format(self.linux_major_version))
 
 
     @property

--- a/roles/build-grsec-kernel/library/grsecurity_urls.py
+++ b/roles/build-grsec-kernel/library/grsecurity_urls.py
@@ -59,6 +59,8 @@ class LinuxKernelURLs():
     def __init__(self, linux_kernel_version):
         self.linux_kernel_version = linux_kernel_version
         self.ansible_facts = dict(
+            linux_base_url=self.linux_base_url,
+            linux_checksums_url=self.linux_checksums_url,
             linux_kernel_version=self.linux_kernel_version,
             linux_major_version=self.linux_major_version,
             linux_tarball_filename=self.linux_tarball_filename,
@@ -89,8 +91,14 @@ class LinuxKernelURLs():
 
 
     @property
+    def linux_checksums_url(self):
+        return urljoin(self.linux_base_url, "sha256sums.asc")
+
+
+    @property
     def linux_tarball_signature_filename(self):
         return "linux-{}.tar.sign".format(self.linux_kernel_version)
+
 
     @property
     def linux_tarball_signature_url(self):

--- a/roles/build-grsec-kernel/tasks/fetch_linux_kernel_source.yml
+++ b/roles/build-grsec-kernel/tasks/fetch_linux_kernel_source.yml
@@ -20,18 +20,18 @@
 
 - name: Read checksum for kernel tarball.
   shell: >
-    grep {{ linux_tarball.filename | quote }}
+    grep {{ linux_tarball_filename | quote }}
     {{ linux_source_checksums.dest | quote }} | cut -d' ' -f1
   changed_when: false
   register: linux_tarball_checksum
 
 - name: Fetch Linux kernel tarball.
   get_url:
-      url: "{{ linux_tarball.url }}"
-      dest: "{{ download_directory }}/{{ linux_tarball.filename }}"
+      url: "{{ linux_tarball_url }}"
+      dest: "{{ download_directory }}/{{ linux_tarball_filename }}"
       sha256sum: "{{ linux_tarball_checksum.stdout }}"
 
 - name: Fetch Linux kernel tarball signature file.
   get_url:
-      url: "{{ linux_tarball_signature.url }}"
+      url: "{{ linux_tarball_signature_url }}"
       dest: "{{ download_directory }}"


### PR DESCRIPTION
The build role was previously using hard-coded vars for Linux kernel versions and download URLs. Since #21, however, the vars are fetched dynamically on each run of the role, so it's safe to remove the static vars from the `defaults/main.yml`.
