### PR TITLE
Fix building 4.x kernels in Vagrant (resubmitted)

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,7 +4,9 @@
 Vagrant.configure("2") do |config|
 
   config.vm.define 'grsec-build', primary: true do |build|
-    build.vm.box = "ubuntu/trusty64"
+    # Using Ubuntu 15.04 rather than 14.04 LTS due to a bug in kernel-package.
+    # See #30 for details: https://github.com/freedomofpress/grsec/issues/30
+    build.vm.box = "ubuntu/vivid64"
     build.vm.hostname = "grsec-build"
 
     build.vm.provision :ansible do |ansible|

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -32,8 +32,11 @@ Vagrant.configure("2") do |config|
   # In case of problems, you don't want to pollute the build machine
   # with the test packages.
   config.vm.define 'grsec-install', autostart: false do |install|
+    # Choose the base box for testing the grsecurity-patched kernel .deb package.
+    # install.vm.box = "debian/wheezy64"
+    # install.vm.box = "debian/jessie64"
+    # install.vm.box = "ubuntu/vivid64"
     install.vm.box = "ubuntu/trusty64"
-    install.vm.box = "debian/jessie64"
     install.vm.hostname = "grsec-install"
     # If grsec install works, the shared folder mount will fail.
     # Set `disabled: true` below to prevent the error post-install.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -42,6 +42,14 @@ Vagrant.configure("2") do |config|
       v.gui = false
     end
 
+    install.vm.provision :ansible do |ansible|
+      ansible.playbook = 'examples/install-grsecurity-kernel.yml'
+      ansible.extra_vars = {
+        # Add the filename for the .deb package created by the build VM.
+        # You may need to prefix the path with '../' if the .deb package is in the repo root.
+        'grsecurity_deb_package' => ''
+      }
+    end
   end
 end
 

--- a/examples/install-grsecurity-kernel.yml
+++ b/examples/install-grsecurity-kernel.yml
@@ -2,7 +2,8 @@
 - name: Install grsecurity-patched kernel deb package.
   hosts: grsec-install
   roles:
-    - { role: install-grsec-kernel,
-        grsecurity_deb_package: linux-image-3.14.57-grsec_10.00.digitalocean_amd64.deb,
-      }
+    - role: install-grsec-kernel
+      # Add the filepath to the .deb package here. The playbook will error out
+      # if the package can't be found.
+      grsecurity_deb_package: ''
   sudo: yes

--- a/roles/build-grsec-kernel/tasks/main.yml
+++ b/roles/build-grsec-kernel/tasks/main.yml
@@ -1,4 +1,8 @@
 ---
+  # Install packages before fetching dynamic URLs, since python-requests
+  # is required by the URL-fetching Ansible module.
+- include: packages.yml
+
 - name: Include grsecurity download URLs.
   # Dynamically reference newest patch and kernel versions,
   # according to patch type 'test' or 'stable'.
@@ -9,8 +13,6 @@
   # vars aren't missing, but we're conditionally including vars.
   tags:
     - always
-
-- include: packages.yml
 
 - include: gpg_keys.yml
 

--- a/roles/build-grsec-kernel/vars/Ubuntu.yml
+++ b/roles/build-grsec-kernel/vars/Ubuntu.yml
@@ -2,8 +2,8 @@
 apt_packages:
   - build-essential
   - fakeroot
-  - gcc-4.8
-  - gcc-4.8-plugin-dev
+  - gcc-4.9
+  - gcc-4.9-plugin-dev
   - git-core
   - kernel-package
   - libncurses5-dev

--- a/roles/build-grsec-kernel/vars/Ubuntu.yml
+++ b/roles/build-grsec-kernel/vars/Ubuntu.yml
@@ -1,10 +1,11 @@
 ---
 apt_packages:
-    - build-essential
-    - fakeroot
-    - gcc-4.8
-    - gcc-4.8-plugin-dev
-    - git-core
-    - kernel-package
-    - libncurses5-dev
-    - make
+  - build-essential
+  - fakeroot
+  - gcc-4.8
+  - gcc-4.8-plugin-dev
+  - git-core
+  - kernel-package
+  - libncurses5-dev
+  - make
+  - python-requests

--- a/roles/install-grsec-kernel/tasks/packages.yml
+++ b/roles/install-grsec-kernel/tasks/packages.yml
@@ -11,7 +11,6 @@
     state: present
   with_items:
     - paxctl
-    - paxtest
 
 - name: Install grsecurity-patched kernel deb package.
   apt:


### PR DESCRIPTION
Rebases the changes presented in #32 on top of the current `master`.
