### PR TITLE
Fixes var interpolation for grsec metapackage

### DIFF
--- a/roles/build-grsec-metapackage/defaults/main.yml
+++ b/roles/build-grsec-metapackage/defaults/main.yml
@@ -6,5 +6,4 @@ securedrop_version: "0.3.5"
 securedrop_architecture: amd64
 
 grsec_package_name_verbose: "{{ grsec_package_name }}-{{ grsec_kernel_version }}-{{ securedrop_architecture }}"
-grsec_build_directory: "{{ grsec_build_parent_directory }}/grsec_package_name_verbose"
-
+grsec_build_directory: "{{ grsec_build_parent_directory }}/{{ grsec_package_name_verbose }}"


### PR DESCRIPTION
The handlebars for Jinja2 templating were omitted, which caused the
directory on the remote host to be misnamed. Still worked, but this is
better.
