### PR TITLE
Make paxctl changes optional

### DIFF
--- a/roles/install-grsec-kernel/defaults/main.yml
+++ b/roles/install-grsec-kernel/defaults/main.yml
@@ -7,3 +7,8 @@ grsecurity_install_grub_timeout: 5
 # This var is required, but can't be known ahead of time. Build the Debian package
 # with the grsecurity build role, then set var to the filepath to the .deb.
 grsecurity_install_deb_package: ''
+
+# paxctld is a better alternative than paxctl for maintaining the PaX flags on binaries.
+# The paxctld role isn't a dependency yet, so assume the paxctl approach is safest.
+# If you're using the paxctld role, set this to false.
+grsecurity_install_set_paxctl_flags: true

--- a/roles/install-grsec-kernel/tasks/grub_config.yml
+++ b/roles/install-grsec-kernel/tasks/grub_config.yml
@@ -1,16 +1,4 @@
 ---
-  # The paxctl flags only apply to a given incarnation of a binary,
-  # so updates to that binary will remove the flags. In the case of grub,
-  # that could leave a system unbootable if versions change.
-- name: Make the required grub paxctl changes.
-  command: paxctl -Cpm {{ item }}
-  with_items:
-    - /usr/sbin/grub-probe
-    - /usr/sbin/grub-mkdevicemap
-    - /usr/bin/grub-script-check
-    - /usr/bin/grub-mount
-  when: grsecurity_install_set_paxctl_flags == true
-
 - name: Find the menu title for the grsecurity kernel in GRUB config.
   set_fact:
     grub_grsecurity_menu_entry: "{{ item }}"

--- a/roles/install-grsec-kernel/tasks/grub_config.yml
+++ b/roles/install-grsec-kernel/tasks/grub_config.yml
@@ -1,11 +1,7 @@
 ---
-  # Not convinced this is necessary, but it doesn't break anything.
-  # Tested removing it, and installation worked fine on VirtualBox
-  # hosts for Debian and Ubuntu. Have NOT tested
-  #   - upgrading grsecurity versions
-  #   - installing and upgrading on hardware
-  # So leaving in until those cases are confirmed working without
-  # the paxctl changes to the GRUB files.
+  # The paxctl flags only apply to a given incarnation of a binary,
+  # so updates to that binary will remove the flags. In the case of grub,
+  # that could leave a system unbootable if versions change.
 - name: Make the required grub paxctl changes.
   command: paxctl -Cpm {{ item }}
   with_items:
@@ -13,6 +9,7 @@
     - /usr/sbin/grub-mkdevicemap
     - /usr/bin/grub-script-check
     - /usr/bin/grub-mount
+  when: grsecurity_install_set_paxctl_flags == true
 
 - name: Find the menu title for the grsecurity kernel in GRUB config.
   set_fact:

--- a/roles/install-grsec-kernel/tasks/main.yml
+++ b/roles/install-grsec-kernel/tasks/main.yml
@@ -5,8 +5,7 @@
 
 - include: disable_python_memprotect.yml
   when: ansible_distribution == "Debian" and
-        grsec_disable_python_memprotect is defined and
-        grsec_disable_python_memprotect == true
+        grsecurity_install_set_paxctl_flags == true
 
 - include: grub_config.yml
 

--- a/roles/install-grsec-kernel/tasks/main.yml
+++ b/roles/install-grsec-kernel/tasks/main.yml
@@ -3,9 +3,8 @@
 
 - include: packages.yml
 
-- include: disable_python_memprotect.yml
-  when: ansible_distribution == "Debian" and
-        grsecurity_install_set_paxctl_flags == true
+- include: paxctl.yml
+  when: grsecurity_install_set_paxctl_flags == true
 
 - include: grub_config.yml
 

--- a/roles/install-grsec-kernel/tasks/packages.yml
+++ b/roles/install-grsec-kernel/tasks/packages.yml
@@ -9,9 +9,10 @@
   apt:
     name: "{{ item }}"
     state: present
-  with_items:
-    - paxctl
-  when: grsecurity_install_set_paxctl_flags == true
+  # Always install paxtest, but allow paxctl to be skipped, in case paxctld is used.
+  with_flattened:
+    - ['paxtest']
+    - "{{ ['paxctl'] if grsecurity_install_set_paxctl_flags else [] }}"
 
 - name: Install grsecurity-patched kernel deb package.
   apt:

--- a/roles/install-grsec-kernel/tasks/packages.yml
+++ b/roles/install-grsec-kernel/tasks/packages.yml
@@ -11,6 +11,7 @@
     state: present
   with_items:
     - paxctl
+  when: grsecurity_install_set_paxctl_flags == true
 
 - name: Install grsecurity-patched kernel deb package.
   apt:

--- a/roles/install-grsec-kernel/tasks/paxctl.yml
+++ b/roles/install-grsec-kernel/tasks/paxctl.yml
@@ -1,4 +1,15 @@
 ---
+  # The paxctl flags only apply to a given incarnation of a binary,
+  # so updates to that binary will remove the flags. In the case of grub,
+  # that could leave a system unbootable if versions change.
+- name: Make the required grub paxctl changes.
+  command: paxctl -Cpm {{ item }}
+  with_items:
+    - /usr/sbin/grub-probe
+    - /usr/sbin/grub-mkdevicemap
+    - /usr/bin/grub-script-check
+    - /usr/bin/grub-mount
+
 - name: Convert python executable headers.
   # Using the `raw` module here because otherwise
   # Ansible would need to execute python2.7 to handle
@@ -6,8 +17,10 @@
   # with "/usr/bin/python2.7: Text file busy". By using
   # `raw`, only localhost's ssh and the remote's sh are used.
   raw: paxctl -c /usr/bin/python2.7
+  when: ansible_distribution == "Debian"
 
 - name: Disable memprotect on python2.7.
   raw: paxctl -m /usr/bin/python2.7
   register: disable_memprotect_python_result
   changed_when: '"converted" in disable_memprotect_python_result.stdout'
+  when: ansible_distribution == "Debian"


### PR DESCRIPTION
Creates a new default var for the install role, `grsecurity_install_set_paxctl_flags`, set to `true`. The role now permits disabling the `paxctl` flags, for example if you want to manage flags with `paxctld` instead (see #38).

Consolidates the paxctl config in a single task list to simplify conditional logic. Also installs `paxtest` by default, since we weren't previously.

I'm using this branch locally to test the install role, and we're fully idempotent with all tests passing—so far, so good!
