### PR TITLE
Namespace default vars in install role

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -50,7 +50,7 @@ Vagrant.configure("2") do |config|
       ansible.extra_vars = {
         # Add the filename for the .deb package created by the build VM.
         # You may need to prefix the path with '../' if the .deb package is in the repo root.
-        'grsecurity_deb_package' => ''
+        #'grsecurity_install_deb_package' => ''
       }
     end
   end

--- a/examples/install-grsecurity-kernel.yml
+++ b/examples/install-grsecurity-kernel.yml
@@ -5,5 +5,5 @@
     - role: install-grsec-kernel
       # Add the filepath to the .deb package here. The playbook will error out
       # if the package can't be found.
-      grsecurity_deb_package: ''
+      #grsecurity_install_deb_package: ''
   become: yes

--- a/roles/install-grsec-kernel/defaults/main.yml
+++ b/roles/install-grsec-kernel/defaults/main.yml
@@ -2,4 +2,8 @@
 # For easier console recovery and debugging, the GRUB timeout value (default: 5) 
 # can be overridden here. Without a lengthier timeout, it can be very difficult
 # to get into the GRUB menu and select a working kernel to boot.
-grub_timeout: 5
+grsecurity_install_grub_timeout: 5
+
+# This var is required, but can't be known ahead of time. Build the Debian package
+# with the grsecurity build role, then set var to the filepath to the .deb.
+grsecurity_install_deb_package: ''

--- a/roles/install-grsec-kernel/tasks/grub_config.yml
+++ b/roles/install-grsec-kernel/tasks/grub_config.yml
@@ -23,7 +23,7 @@
   #   Debian GNU/Linux, with Linux 3.14.54-grsec
   # Example string NOT to match:
   #   Debian GNU/Linux, with Linux 3.14.54-grsec (recovery mode)
-  when: "{{ item.name | match('.*'+grsecurity_desired_kernel_version+'$') }}"
+  when: "{{ item.name | match('.*'+grsecurity_install_desired_kernel_version+'$') }}"
 
 - name: Update GRUB timeout for easier console recovery and debugging           
   lineinfile:
@@ -34,7 +34,7 @@
 - name: Ensure grsecurity kernel menu entry is populated.
   fail:
     msg: >
-      Could not find GRUB menu entry for grsecurity kernel {{ grsecurity_desired_kernel_version }}.
+      Could not find GRUB menu entry for grsecurity kernel {{ grsecurity_install_desired_kernel_version }}.
       Try installing manually via `dpkg -i <package_name>` and verifying the menu
       entry exists in the GRUB config file.
   when: grub_grsecurity_menu_entry is not defined

--- a/roles/install-grsec-kernel/tasks/grub_config.yml
+++ b/roles/install-grsec-kernel/tasks/grub_config.yml
@@ -28,7 +28,7 @@
 - name: Update GRUB timeout for easier console recovery and debugging           
   lineinfile:
     regexp: '^GRUB_TIMEOUT=.*$'
-    line: "GRUB_TIMEOUT={{ grub_timeout }}"
+    line: "GRUB_TIMEOUT={{ grsecurity_install_grub_timeout }}"
     dest: /etc/default/grub
 
 - name: Ensure grsecurity kernel menu entry is populated.

--- a/roles/install-grsec-kernel/tasks/main.yml
+++ b/roles/install-grsec-kernel/tasks/main.yml
@@ -11,5 +11,5 @@
 - include: grub_config.yml
 
 - include: validate_install.yml
-  when: grsecurity_desired_kernel_version != ansible_kernel
+  when: grsecurity_install_desired_kernel_version != ansible_kernel
 

--- a/roles/install-grsec-kernel/tasks/packages.yml
+++ b/roles/install-grsec-kernel/tasks/packages.yml
@@ -3,7 +3,7 @@
   copy:
     src: "{{ grsecurity_install_deb_package }}"
     dest: "/root/{{ grsecurity_install_deb_package | basename }}"
-  when: grsecurity_desired_kernel_version != ansible_kernel
+  when: grsecurity_install_desired_kernel_version != ansible_kernel
 
 - name: Install PaX utilities.
   apt:
@@ -19,7 +19,7 @@
     # about overwriting lib modules. A subsequent task will validate
     # that a grsec-patched kernel is actually running.
     dpkg_options: skip-same-version,force-confdef,force-confold
-  when: grsecurity_desired_kernel_version != ansible_kernel
+  when: grsecurity_install_desired_kernel_version != ansible_kernel
   notify:
     - Update GRUB.
     - Update host facts.

--- a/roles/install-grsec-kernel/tasks/packages.yml
+++ b/roles/install-grsec-kernel/tasks/packages.yml
@@ -1,8 +1,8 @@
 ---
 - name: Copy kernel image deb package.
   copy:
-    src: "{{ grsecurity_deb_package }}"
-    dest: "/root/{{ grsecurity_deb_package | basename }}"
+    src: "{{ grsecurity_install_deb_package }}"
+    dest: "/root/{{ grsecurity_install_deb_package | basename }}"
   when: grsecurity_desired_kernel_version != ansible_kernel
 
 - name: Install PaX utilities.
@@ -14,7 +14,7 @@
 
 - name: Install grsecurity-patched kernel deb package.
   apt:
-    deb: /root/{{ grsecurity_deb_package | basename }}
+    deb: /root/{{ grsecurity_install_deb_package | basename }}
     # Adding --skip-same-version to avoid an interactive dpkg prompt
     # about overwriting lib modules. A subsequent task will validate
     # that a grsec-patched kernel is actually running.

--- a/roles/install-grsec-kernel/tasks/set_host_facts.yml
+++ b/roles/install-grsec-kernel/tasks/set_host_facts.yml
@@ -2,16 +2,17 @@
 - name: Get GRUB menu options as host facts.
   action: grub_menu_options
 
-  # Role requires that `grsecurity_deb_package` be defined.
+  # Role requires that `grsecurity_install_deb_package` be defined.
 - name: Check filename for deb package.
   fail:
     msg: >
       No deb package specified for installation.
-      Define the variable 'grsecurity_deb_package'
+      Define the variable 'grsecurity_install_deb_package'
       with the filepath to the local .deb package,
       then rerun the playbook.
-  when: grsecurity_deb_package is not defined
+  when: grsecurity_install_deb_package is not defined
 
 - name: Set desired kernel version as host fact.
-  set_fact: grsecurity_desired_kernel_version="{{ grsecurity_deb_package | basename | regex_replace('^linux-image-([\d\.]+-grsec)_.*$', '\\1') }}"
-
+  # Intentionally using key=value syntax to support Ansible v1 and v2,
+  # which have different escaping rules for the regex_replace filter.
+  set_fact: grsecurity_desired_kernel_version="{{ grsecurity_install_deb_package | basename | regex_replace('^linux-image-([\d\.]+-grsec)_.*$', '\\1') }}"

--- a/roles/install-grsec-kernel/tasks/set_host_facts.yml
+++ b/roles/install-grsec-kernel/tasks/set_host_facts.yml
@@ -15,4 +15,4 @@
 - name: Set desired kernel version as host fact.
   # Intentionally using key=value syntax to support Ansible v1 and v2,
   # which have different escaping rules for the regex_replace filter.
-  set_fact: grsecurity_desired_kernel_version="{{ grsecurity_install_deb_package | basename | regex_replace('^linux-image-([\d\.]+-grsec)_.*$', '\\1') }}"
+  set_fact: grsecurity_install_desired_kernel_version="{{ grsecurity_install_deb_package | basename | regex_replace('^linux-image-([\d\.]+-grsec)_.*$', '\\1') }}"

--- a/roles/install-grsec-kernel/tasks/validate_install.yml
+++ b/roles/install-grsec-kernel/tasks/validate_install.yml
@@ -25,7 +25,7 @@
     seconds: 30
 
   # Running the setup module will refresh the `ansible_kernel` host fact
-  # with the current value. The `grsecurity_desired_kernel_version` host fact
+  # with the current value. The `grsecurity_install_desired_kernel_version` host fact
   # persists from when it was set earlier in the role.
 - name: Refresh host facts.
   action: setup
@@ -34,5 +34,5 @@
   fail:
     msg: >
       Grsecurity kernel is not running. Expected to find
-      {{ grsecurity_desired_kernel_version }}. Instead, found
+      {{ grsecurity_install_desired_kernel_version }}. Instead, found
       kernel {{ ansible_kernel }}.


### PR DESCRIPTION
Prefixes default vars for the install role with `grsecurity_install_`. Doing so avoids variable collisions, in the very real example of variable reuse—the build and install role both had a var called `grsecurity_deb_package` and site-wide declarations of that var broke one of the roles, depending on which meaning you used.

The var is now called `grsecurity_install_deb_package`; a separate PR can namespace the build-role vars, before for now it's enough that they're distinct. Updated all instances and added some helpful comments.
