### PR TITLE
Smarter privilege escalation 

### DIFF
--- a/examples/build-grsecurity-kernel-test.yml
+++ b/examples/build-grsecurity-kernel-test.yml
@@ -2,9 +2,6 @@
 - name: Build Linux kernel with grsecurity test patches.
   hosts: grsec-build
   roles:
-    - role: build-grsec-metapackage
-      tags: metapackage
-
     - role: build-grsec-kernel
       grsecurity_patch_type: test
       tags: kernel

--- a/examples/install-grsecurity-kernel.yml
+++ b/examples/install-grsecurity-kernel.yml
@@ -4,6 +4,6 @@
   roles:
     - role: install-grsec-kernel
       # Add the filepath to the .deb package here. The playbook will error out
-      # if the package can't be found.
-      #grsecurity_install_deb_package: ''
-  become: yes
+      # if the package can't be found. If you're referencing this playbook while it's
+      # still inside the "examples" directory, you may have to precede the filename with "../".
+      # grsecurity_install_deb_package: ''

--- a/roles/build-grsec-kernel/defaults/main.yml
+++ b/roles/build-grsec-kernel/defaults/main.yml
@@ -27,7 +27,7 @@ grsecurity_build_include_ubuntu_overlay: false
 
 grsecurity_build_download_directory: "{{ ansible_env.HOME }}/linux"
 
-linux_source_directory: "{{ grsecurity_build_download_directory }}/linux-{{ linux_kernel_version }}"
+grsecurity_build_linux_source_directory: "{{ grsecurity_build_download_directory }}/linux-{{ linux_kernel_version }}"
 gpg_keyserver: hkps.pool.sks-keyservers.net
 
 # Assumes 64-bit (not reading machine architecture dynamically.)

--- a/roles/build-grsec-kernel/defaults/main.yml
+++ b/roles/build-grsec-kernel/defaults/main.yml
@@ -3,7 +3,7 @@
 # requires authentication to download. See the grsecurity
 # blog for more information:
 # https://grsecurity.net/announce.php
-grsecurity_patch_type: test
+grsecurity_build_patch_type: test
 
 # Declaring a list of supported distributions
 # for package dependency lists. Role will fail

--- a/roles/build-grsec-kernel/defaults/main.yml
+++ b/roles/build-grsec-kernel/defaults/main.yml
@@ -31,6 +31,6 @@ grsecurity_build_linux_source_directory: "{{ grsecurity_build_download_directory
 grsecurity_build_gpg_keyserver: hkps.pool.sks-keyservers.net
 
 # Assumes 64-bit (not reading machine architecture dynamically.)
-grsecurity_deb_package: linux-image-{{ linux_kernel_version }}-grsec_10.00.{{ grsecurity_build_strategy }}_amd64.deb
+grsecurity_build_deb_package: linux-image-{{ linux_kernel_version }}-grsec_10.00.{{ grsecurity_build_strategy }}_amd64.deb
 
 grsecurity_use_ccache: true

--- a/roles/build-grsec-kernel/defaults/main.yml
+++ b/roles/build-grsec-kernel/defaults/main.yml
@@ -25,9 +25,9 @@ grsecurity_build_strategy: manual
 # just postinstall scripts. Off by default.
 grsecurity_build_include_ubuntu_overlay: false
 
-download_directory: "{{ ansible_env.HOME }}/linux"
+grsecurity_build_download_directory: "{{ ansible_env.HOME }}/linux"
 
-linux_source_directory: "{{ download_directory }}/linux-{{ linux_kernel_version }}"
+linux_source_directory: "{{ grsecurity_build_download_directory }}/linux-{{ linux_kernel_version }}"
 gpg_keyserver: hkps.pool.sks-keyservers.net
 
 # Assumes 64-bit (not reading machine architecture dynamically.)

--- a/roles/build-grsec-kernel/defaults/main.yml
+++ b/roles/build-grsec-kernel/defaults/main.yml
@@ -33,7 +33,7 @@ grsecurity_build_strategy: manual
 # just postinstall scripts. Off by default.
 include_ubuntu_overlay: false
 
-download_directory: /usr/local/src
+download_directory: "{{ ansible_env.HOME }}/linux"
 
 linux_source_directory: "{{ download_directory }}/linux-{{ linux_kernel_version }}"
 gpg_keyserver: hkps.pool.sks-keyservers.net

--- a/roles/build-grsec-kernel/defaults/main.yml
+++ b/roles/build-grsec-kernel/defaults/main.yml
@@ -28,7 +28,7 @@ grsecurity_build_include_ubuntu_overlay: false
 grsecurity_build_download_directory: "{{ ansible_env.HOME }}/linux"
 
 grsecurity_build_linux_source_directory: "{{ grsecurity_build_download_directory }}/linux-{{ linux_kernel_version }}"
-gpg_keyserver: hkps.pool.sks-keyservers.net
+grsecurity_build_gpg_keyserver: hkps.pool.sks-keyservers.net
 
 # Assumes 64-bit (not reading machine architecture dynamically.)
 grsecurity_deb_package: linux-image-{{ linux_kernel_version }}-grsec_10.00.{{ grsecurity_build_strategy }}_amd64.deb

--- a/roles/build-grsec-kernel/defaults/main.yml
+++ b/roles/build-grsec-kernel/defaults/main.yml
@@ -23,7 +23,7 @@ grsecurity_build_strategy: manual
 # When targeting an Ubuntu host, there are a few tricks
 # that should be pulled in via the ubuntu-overlay, mostly
 # just postinstall scripts. Off by default.
-include_ubuntu_overlay: false
+grsecurity_build_include_ubuntu_overlay: false
 
 download_directory: "{{ ansible_env.HOME }}/linux"
 

--- a/roles/build-grsec-kernel/defaults/main.yml
+++ b/roles/build-grsec-kernel/defaults/main.yml
@@ -5,14 +5,6 @@
 # https://grsecurity.net/announce.php
 grsecurity_build_patch_type: test
 
-# Declaring a list of supported distributions
-# for package dependency lists. Role will fail
-# if playbook attempts to compile under a different OS,
-# with a helpful message soliciting a PR. =)
-supported_linux_distributions:
-  - Debian
-  - Ubuntu
-
 # The default "manual" strategy will prep a machine for
 # for compilation, but stop short of configuring and running
 # `make`, to allow the admin to run `make menuconfig`.

--- a/roles/build-grsec-kernel/defaults/main.yml
+++ b/roles/build-grsec-kernel/defaults/main.yml
@@ -33,4 +33,4 @@ grsecurity_build_gpg_keyserver: hkps.pool.sks-keyservers.net
 # Assumes 64-bit (not reading machine architecture dynamically.)
 grsecurity_build_deb_package: linux-image-{{ linux_kernel_version }}-grsec_10.00.{{ grsecurity_build_strategy }}_amd64.deb
 
-grsecurity_use_ccache: true
+grsecurity_build_use_ccache: true

--- a/roles/build-grsec-kernel/tasks/ccache.yml
+++ b/roles/build-grsec-kernel/tasks/ccache.yml
@@ -1,6 +1,6 @@
 ---
 # Separate task list for ccache-related tasks,
-# to make dynamic inclusion easier. If grsecurity_use_ccache
+# to make dynamic inclusion easier. If grsecurity_build_use_ccache
 # is set to `false`, then the package won't even be installed.
 - name: Install ccache.
   apt:

--- a/roles/build-grsec-kernel/tasks/compile.yml
+++ b/roles/build-grsec-kernel/tasks/compile.yml
@@ -15,7 +15,7 @@
 
 - name: Fetch built kernel package back to localhost.
   fetch:
-    src: "{{ grsecurity_build_download_directory }}/{{ grsecurity_deb_package }}"
+    src: "{{ grsecurity_build_download_directory }}/{{ grsecurity_build_deb_package }}"
     dest: ./
     fail_on_missing: yes
     flat: yes

--- a/roles/build-grsec-kernel/tasks/compile.yml
+++ b/roles/build-grsec-kernel/tasks/compile.yml
@@ -6,7 +6,7 @@
     {% if grsecurity_build_include_ubuntu_overlay == true %} --overlay-dir=../ubuntu-package {% endif %}
     --initrd kernel_image
   args:
-    chdir: "{{ linux_source_directory }}"
+    chdir: "{{ grsecurity_build_linux_source_directory }}"
   environment:
     CONCURRENCY_LEVEL: "{{ ansible_processor_vcpus }}"
     # Conditionally enable ccache by prepending the ccache lib directory

--- a/roles/build-grsec-kernel/tasks/compile.yml
+++ b/roles/build-grsec-kernel/tasks/compile.yml
@@ -11,7 +11,7 @@
     CONCURRENCY_LEVEL: "{{ ansible_processor_vcpus }}"
     # Conditionally enable ccache by prepending the ccache lib directory
     # to PATH, which will override the system gcc and and g++ binaries.
-    PATH: "{% if grsecurity_use_ccache == true %}/usr/lib/ccache:{% endif %}{{ ansible_env.PATH }}"
+    PATH: "{% if grsecurity_build_use_ccache == true %}/usr/lib/ccache:{% endif %}{{ ansible_env.PATH }}"
 
 - name: Fetch built kernel package back to localhost.
   fetch:

--- a/roles/build-grsec-kernel/tasks/compile.yml
+++ b/roles/build-grsec-kernel/tasks/compile.yml
@@ -3,7 +3,7 @@
   command: >
     fakeroot make-kpkg
     --revision 10.00.{{ grsecurity_build_strategy }}
-    {% if include_ubuntu_overlay == true %} --overlay-dir=../ubuntu-package {% endif %}
+    {% if grsecurity_build_include_ubuntu_overlay == true %} --overlay-dir=../ubuntu-package {% endif %}
     --initrd kernel_image
   args:
     chdir: "{{ linux_source_directory }}"

--- a/roles/build-grsec-kernel/tasks/compile.yml
+++ b/roles/build-grsec-kernel/tasks/compile.yml
@@ -15,7 +15,7 @@
 
 - name: Fetch built kernel package back to localhost.
   fetch:
-    src: "{{ download_directory }}/{{ grsecurity_deb_package }}"
+    src: "{{ grsecurity_build_download_directory }}/{{ grsecurity_deb_package }}"
     dest: ./
     fail_on_missing: yes
     flat: yes

--- a/roles/build-grsec-kernel/tasks/configure.yml
+++ b/roles/build-grsec-kernel/tasks/configure.yml
@@ -2,16 +2,16 @@
 - name: Copy baseline grsecurity config template.
   copy:
     src: config-{{ grsecurity_build_strategy }}
-    dest: "{{ linux_source_directory }}/.config"
+    dest: "{{ grsecurity_build_linux_source_directory }}/.config"
 
 - name: Ensure any new options are updated with defaults.
   command: make olddefconfig
   args:
-    chdir: "{{ linux_source_directory }}"
+    chdir: "{{ grsecurity_build_linux_source_directory }}"
 
 - name: Check that grsecurity options are enabled.
   lineinfile:
-    dest: "{{ linux_source_directory }}/.config"
+    dest: "{{ grsecurity_build_linux_source_directory }}/.config"
     regexp: "# CONFIG_GRKERNSEC is not set"
     state: absent
   register: grsecurity_settings_check_result

--- a/roles/build-grsec-kernel/tasks/fetch_grsecurity_files.yml
+++ b/roles/build-grsec-kernel/tasks/fetch_grsecurity_files.yml
@@ -2,13 +2,13 @@
 - name: Fetch grsecurity patch.
   get_url:
       url: "{{ grsecurity_patch_url  }}"
-      dest: "{{ download_directory }}/{{ grsecurity_patch_filename }}"
+      dest: "{{ grsecurity_build_download_directory }}/{{ grsecurity_patch_filename }}"
       url_username: "{{ grsecurity_download_username | default('') }}"
       url_password: "{{ grsecurity_download_password | default('') }}"
 
 - name: Fetch grsecurity signature.
   get_url:
       url: "{{ grsecurity_signature_url  }}"
-      dest: "{{ download_directory }}/{{ grsecurity_signature_filename }}"
+      dest: "{{ grsecurity_build_download_directory }}/{{ grsecurity_signature_filename }}"
       url_username: "{{ grsecurity_download_username | default('') }}"
       url_password: "{{ grsecurity_download_password | default('') }}"

--- a/roles/build-grsec-kernel/tasks/fetch_linux_kernel_source.yml
+++ b/roles/build-grsec-kernel/tasks/fetch_linux_kernel_source.yml
@@ -2,7 +2,7 @@
 - name: Create directory for downloaded files.
   file:
     state: directory
-    dest: "{{ download_directory }}"
+    dest: "{{ grsecurity_build_download_directory }}"
     owner: "{{ ansible_ssh_user }}"
     group: "{{ ansible_ssh_user }}"
     mode: "0755"
@@ -10,7 +10,7 @@
 - name: Fetch SHA256 checksums for Linux source files.
   get_url:
     url: "{{ linux_checksums_url }}"
-    dest: "{{ download_directory }}"
+    dest: "{{ grsecurity_build_download_directory }}"
   register: linux_source_checksums
 
 - name: Verify GPG signature on SHA256 checksum file.
@@ -27,10 +27,10 @@
 - name: Fetch Linux kernel tarball.
   get_url:
       url: "{{ linux_tarball_url }}"
-      dest: "{{ download_directory }}/{{ linux_tarball_filename }}"
+      dest: "{{ grsecurity_build_download_directory }}/{{ linux_tarball_filename }}"
       sha256sum: "{{ linux_tarball_checksum.stdout }}"
 
 - name: Fetch Linux kernel tarball signature file.
   get_url:
       url: "{{ linux_tarball_signature_url }}"
-      dest: "{{ download_directory }}"
+      dest: "{{ grsecurity_build_download_directory }}"

--- a/roles/build-grsec-kernel/tasks/fetch_linux_kernel_source.yml
+++ b/roles/build-grsec-kernel/tasks/fetch_linux_kernel_source.yml
@@ -6,7 +6,6 @@
     owner: "{{ ansible_ssh_user }}"
     group: "{{ ansible_ssh_user }}"
     mode: "0755"
-  become: yes
 
 - name: Fetch SHA256 checksums for Linux source files.
   get_url:

--- a/roles/build-grsec-kernel/tasks/fetch_ubuntu_overlay.yml
+++ b/roles/build-grsec-kernel/tasks/fetch_ubuntu_overlay.yml
@@ -2,7 +2,7 @@
 - name: clone ubuntu overlay git repository (slow!)
   git:
     repo: git://kernel.ubuntu.com/ubuntu/ubuntu-trusty.git
-    dest: "{{ download_directory }}/ubuntu-trusty"
+    dest: "{{ grsecurity_build_download_directory }}/ubuntu-trusty"
     force: yes
     # since this clone takes a long time, just grab
     # the first layer. can then pull manually to update.
@@ -15,14 +15,14 @@
     - git
 
 - name: copy kernel package files
-  command: cp -a /usr/share/kernel-package {{ download_directory }}/ubuntu-package
+  command: cp -a /usr/share/kernel-package {{ grsecurity_build_download_directory }}/ubuntu-package
   args:
-    creates: "{{ download_directory }}/ubuntu-package"
+    creates: "{{ grsecurity_build_download_directory }}/ubuntu-package"
 
 - name: copy ubuntu overlay control files
   command: >
-     cp {{ download_directory }}/ubuntu-trusty/debian/control-scripts/{{ item }}
-        {{ download_directory }}/ubuntu-package/pkg/image/
+     cp {{ grsecurity_build_download_directory }}/ubuntu-trusty/debian/control-scripts/{{ item }}
+        {{ grsecurity_build_download_directory }}/ubuntu-package/pkg/image/
   with_items:
     - postinst
     - postrm
@@ -31,5 +31,5 @@
 
 - name: copy ubuntu overlay header files
   command: >
-     cp {{ download_directory }}/ubuntu-trusty/debian/control-scripts/headers-postinst \
-        {{ download_directory }}/ubuntu-package/pkg/headers/
+     cp {{ grsecurity_build_download_directory }}/ubuntu-trusty/debian/control-scripts/headers-postinst \
+        {{ grsecurity_build_download_directory }}/ubuntu-package/pkg/headers/

--- a/roles/build-grsec-kernel/tasks/gpg_keys.yml
+++ b/roles/build-grsec-kernel/tasks/gpg_keys.yml
@@ -18,11 +18,11 @@
   command: gpg --keyserver {{ gpg_keyserver }} --recv-keys 0C7B589B105BE7F7
   register: gpg_import_figg_result
   changed_when: "'imported: 1' in gpg_import_figg_result.stderr"
-  when: include_ubuntu_overlay == true
+  when: grsecurity_build_include_ubuntu_overlay == true
 
 - name: Import Luis Henriques GPG key (Canonical/LKM).
   command: gpg --keyserver {{ gpg_keyserver }} --recv-keys DB74AEB8FDCE24FC
   register: gpg_henriques_import
   changed_when: "'imported: 1' in gpg_henriques_import.stderr"
-  when: include_ubuntu_overlay == true
+  when: grsecurity_build_include_ubuntu_overlay == true
 

--- a/roles/build-grsec-kernel/tasks/gpg_keys.yml
+++ b/roles/build-grsec-kernel/tasks/gpg_keys.yml
@@ -1,27 +1,27 @@
 ---
 - name: Import Greg Kroah-Hartman GPG key (Linux stable release signing key).
-  command: gpg --keyserver {{ gpg_keyserver }} --recv-keys 38DBBDC86092693E
+  command: gpg --keyserver {{ grsecurity_build_gpg_keyserver }} --recv-keys 38DBBDC86092693E
   register: gpg_import_greg_result
   changed_when: "'imported: 1' in gpg_import_greg_result.stderr"
 
 - name: Import kernel.org checksum autosigner GPG key.
-  command: gpg --keyserver {{ gpg_keyserver }} --recv-keys 632D3A06589DA6B1
+  command: gpg --keyserver {{ grsecurity_build_gpg_keyserver }} --recv-keys 632D3A06589DA6B1
   register: gpg_import_autosigner_result
   changed_when: "'imported: 1' in gpg_import_autosigner_result.stderr"
 
 - name: Import Bradley Spengler GPG key (grsecurity maintainer key).
-  command: gpg --keyserver {{ gpg_keyserver }} --recv-keys 44D1C0F82525FE49
+  command: gpg --keyserver {{ grsecurity_build_gpg_keyserver }} --recv-keys 44D1C0F82525FE49
   register: gpg_import_spender_result
   changed_when: "'imported: 1' in gpg_import_spender_result.stderr"
 
 - name: Import Brad Figg GPG key (Canonical/Ubuntu Kernel Team).
-  command: gpg --keyserver {{ gpg_keyserver }} --recv-keys 0C7B589B105BE7F7
+  command: gpg --keyserver {{ grsecurity_build_gpg_keyserver }} --recv-keys 0C7B589B105BE7F7
   register: gpg_import_figg_result
   changed_when: "'imported: 1' in gpg_import_figg_result.stderr"
   when: grsecurity_build_include_ubuntu_overlay == true
 
 - name: Import Luis Henriques GPG key (Canonical/LKM).
-  command: gpg --keyserver {{ gpg_keyserver }} --recv-keys DB74AEB8FDCE24FC
+  command: gpg --keyserver {{ grsecurity_build_gpg_keyserver }} --recv-keys DB74AEB8FDCE24FC
   register: gpg_henriques_import
   changed_when: "'imported: 1' in gpg_henriques_import.stderr"
   when: grsecurity_build_include_ubuntu_overlay == true

--- a/roles/build-grsec-kernel/tasks/main.yml
+++ b/roles/build-grsec-kernel/tasks/main.yml
@@ -31,7 +31,7 @@
 - include: fetch_grsecurity_files.yml
 
 - include: fetch_ubuntu_overlay.yml
-  when: include_ubuntu_overlay == true
+  when: grsecurity_build_include_ubuntu_overlay == true
 
 - include: verify.yml
 

--- a/roles/build-grsec-kernel/tasks/main.yml
+++ b/roles/build-grsec-kernel/tasks/main.yml
@@ -1,4 +1,14 @@
 ---
+- name: Stop if running with elevated privileges.
+  fail:
+    msg: >
+      WARNING! You should not compile the Linux kernel with
+      superuser privileges. Doing so may create an unbootable
+      system. See Greg Kroah-Hartmann's Linux Kernel in a Nutshell
+      for anecdotes about how doing so has broken systems
+      in the past: http://www.kroah.com/lkn/
+  when: ansible_ssh_user == 'root' or ansible_user_id == 'root'
+
   # Install packages before fetching dynamic URLs, since python-requests
   # is required by the URL-fetching Ansible module.
 - include: packages.yml

--- a/roles/build-grsec-kernel/tasks/main.yml
+++ b/roles/build-grsec-kernel/tasks/main.yml
@@ -36,7 +36,7 @@
 - include: verify.yml
 
 - include: ccache.yml
-  when: grsecurity_use_ccache == true
+  when: grsecurity_build_use_ccache == true
 
 - include: prepare_source_directory.yml
   tags: prepare

--- a/roles/build-grsec-kernel/tasks/main.yml
+++ b/roles/build-grsec-kernel/tasks/main.yml
@@ -17,7 +17,7 @@
   # Dynamically reference newest patch and kernel versions,
   # according to patch type 'test' or 'stable'.
   grsecurity_urls:
-    patch_type: "{{ grsecurity_patch_type }}"
+    patch_type: "{{ grsecurity_build_patch_type }}"
   # Setting task to "always" run, because other tasks will
   # without the imported vars. Usually defaults would handle ensuring
   # vars aren't missing, but we're conditionally including vars.

--- a/roles/build-grsec-kernel/tasks/packages.yml
+++ b/roles/build-grsec-kernel/tasks/packages.yml
@@ -6,7 +6,8 @@
       The problem may be as simple as a few missing package
       dependencies. Send a pull request to add support for your distro!
       https://github.com/freedomofpress/grsec
-  when: 'ansible_distribution not in supported_linux_distributions'
+  when: ansible_distribution != "Debian" and
+        ansible_distribution != "Ubuntu"
 
 - name: Import OS-specific dependency list.
   include_vars: "{{ ansible_distribution }}.yml"

--- a/roles/build-grsec-kernel/tasks/prepare_source_directory.yml
+++ b/roles/build-grsec-kernel/tasks/prepare_source_directory.yml
@@ -1,7 +1,7 @@
 ---
 - name: Clean source directory prior to extraction.
   file:
-    path: "{{ linux_source_directory }}"
+    path: "{{ grsecurity_build_linux_source_directory }}"
     state: absent
 
 - name: Extract Linux tarball (.tar -> directory).
@@ -14,7 +14,7 @@
   patch:
     remote_src: true
     src: "{{ grsecurity_build_download_directory }}/{{ grsecurity_patch_filename }}"
-    basedir: "{{ linux_source_directory }}"
+    basedir: "{{ grsecurity_build_linux_source_directory }}"
     strip: 1
 
   # Using `make-kpkg` wrapper script rather than core `make`
@@ -28,7 +28,7 @@
 - name: Clean kernel source tree.
   command: make-kpkg clean
   args:
-    chdir: "{{ linux_source_directory }}"
+    chdir: "{{ grsecurity_build_linux_source_directory }}"
 
   # Bail out for interactive compilation. Override interactive mode
   # by setting `grsecurity_build_strategy`
@@ -36,7 +36,7 @@
   debug:
     msg: >
       Build environment ready. Kernel source is available in
-      {{ linux_source_directory }} . Run `make menuconfig` in that
+      {{ grsecurity_build_linux_source_directory }} . Run `make menuconfig` in that
       directory to configure the build, then `make-kpkg kernel_image`
       or similar to begin compiling the kernel.
   when: grsecurity_build_strategy == "manual"

--- a/roles/build-grsec-kernel/tasks/prepare_source_directory.yml
+++ b/roles/build-grsec-kernel/tasks/prepare_source_directory.yml
@@ -7,13 +7,13 @@
 - name: Extract Linux tarball (.tar -> directory).
   unarchive:
     copy: no
-    src: "{{ download_directory }}/linux-{{ linux_kernel_version }}.tar"
-    dest: "{{ download_directory }}"
+    src: "{{ grsecurity_build_download_directory }}/linux-{{ linux_kernel_version }}.tar"
+    dest: "{{ grsecurity_build_download_directory }}"
 
 - name: Apply grsecurity patch.
   patch:
     remote_src: true
-    src: "{{ download_directory }}/{{ grsecurity_patch_filename }}"
+    src: "{{ grsecurity_build_download_directory }}/{{ grsecurity_patch_filename }}"
     basedir: "{{ linux_source_directory }}"
     strip: 1
 

--- a/roles/build-grsec-kernel/tasks/verify.yml
+++ b/roles/build-grsec-kernel/tasks/verify.yml
@@ -22,11 +22,11 @@
     chdir: "{{ download_directory }}/ubuntu-trusty"
   register: ubuntu_overlay_tag_result
   changed_when: false
-  when: include_ubuntu_overlay == true
+  when: grsecurity_build_include_ubuntu_overlay == true
 
 - name: Verify Ubuntu overlay signature.
   command: git tag --verify {{ ubuntu_overlay_tag_result.stdout }}
   args:
     chdir: "{{ download_directory }}/ubuntu-trusty"
   changed_when: false
-  when: include_ubuntu_overlay == true
+  when: grsecurity_build_include_ubuntu_overlay == true

--- a/roles/build-grsec-kernel/tasks/verify.yml
+++ b/roles/build-grsec-kernel/tasks/verify.yml
@@ -5,21 +5,21 @@
   # Intentionally using key=value syntax to support Ansible v1 and v2,
   # which have different escaping rules for the regex_replace filter.
   command: >
-    xz --decompress {{ download_directory }}/{{ linux_tarball_filename }}
-    creates="{{ download_directory }}/{{ linux_tarball_filename|regex_replace('(.*)\\.xz$', '\\1') }}"
+    xz --decompress {{ grsecurity_build_download_directory }}/{{ linux_tarball_filename }}
+    creates="{{ grsecurity_build_download_directory }}/{{ linux_tarball_filename|regex_replace('(.*)\\.xz$', '\\1') }}"
 
 - name: Verify Linux tarball GPG signature.
-  command: gpg --verify {{ download_directory }}/{{ linux_tarball_signature_filename }}
+  command: gpg --verify {{ grsecurity_build_download_directory }}/{{ linux_tarball_signature_filename }}
   changed_when: false
 
 - name: Verify grsecurity patch GPG signature.
-  command: gpg --verify {{ download_directory }}/{{ grsecurity_signature_filename }}
+  command: gpg --verify {{ grsecurity_build_download_directory }}/{{ grsecurity_signature_filename }}
   changed_when: false
 
 - name: Register current release tag for Ubuntu overlay.
   command: git tag
   args:
-    chdir: "{{ download_directory }}/ubuntu-trusty"
+    chdir: "{{ grsecurity_build_download_directory }}/ubuntu-trusty"
   register: ubuntu_overlay_tag_result
   changed_when: false
   when: grsecurity_build_include_ubuntu_overlay == true
@@ -27,6 +27,6 @@
 - name: Verify Ubuntu overlay signature.
   command: git tag --verify {{ ubuntu_overlay_tag_result.stdout }}
   args:
-    chdir: "{{ download_directory }}/ubuntu-trusty"
+    chdir: "{{ grsecurity_build_download_directory }}/ubuntu-trusty"
   changed_when: false
   when: grsecurity_build_include_ubuntu_overlay == true

--- a/roles/build-grsec-kernel/tasks/verify.yml
+++ b/roles/build-grsec-kernel/tasks/verify.yml
@@ -2,9 +2,11 @@
 - name: Extract Linux tarball (.xz -> .tar).
   # Can't use the `unarchive` module here, because it destroys
   # the intermediary .tar file, which we need to verify the GPG sig.
-  command: xz --decompress {{ download_directory }}/{{ linux_tarball_filename }}
-  args:
-    creates: "{{ download_directory }}/{{ linux_tarball_filename|regex_replace('(.*)\\.xz$', '\\\\1') }}"
+  # Intentionally using key=value syntax to support Ansible v1 and v2,
+  # which have different escaping rules for the regex_replace filter.
+  command: >
+    xz --decompress {{ download_directory }}/{{ linux_tarball_filename }}
+    creates="{{ download_directory }}/{{ linux_tarball_filename|regex_replace('(.*)\\.xz$', '\\1') }}"
 
 - name: Verify Linux tarball GPG signature.
   command: gpg --verify {{ download_directory }}/{{ linux_tarball_signature_filename }}

--- a/roles/install-grsec-kernel/defaults/main.yml
+++ b/roles/install-grsec-kernel/defaults/main.yml
@@ -12,3 +12,5 @@ grsecurity_install_deb_package: ''
 # The paxctld role isn't a dependency yet, so assume the paxctl approach is safest.
 # If you're using the paxctld role, set this to false.
 grsecurity_install_set_paxctl_flags: true
+
+grsecurity_install_download_dir: /usr/local/src

--- a/roles/install-grsec-kernel/defaults/main.yml
+++ b/roles/install-grsec-kernel/defaults/main.yml
@@ -14,3 +14,8 @@ grsecurity_install_deb_package: ''
 grsecurity_install_set_paxctl_flags: true
 
 grsecurity_install_download_dir: /usr/local/src
+
+# The role skip installation if the kernel version, e.g. "4.4.2-grsec", for the deb
+# packages matches that of the target host, provided the checksum for the deb file
+# is the same.
+grsecurity_install_force_install: false

--- a/roles/install-grsec-kernel/handlers/main.yml
+++ b/roles/install-grsec-kernel/handlers/main.yml
@@ -1,9 +1,11 @@
 ---
 - name: Update GRUB.
   command: update-grub
+  become: yes
 
 - name: Update host facts.
   action: "{{ item }}"
+  become: yes
   with_items:
     - setup
     - grub_menu_options

--- a/roles/install-grsec-kernel/tasks/grub_config.yml
+++ b/roles/install-grsec-kernel/tasks/grub_config.yml
@@ -11,6 +11,7 @@
   when: "{{ item.name | match('.*'+grsecurity_install_desired_kernel_version+'$') }}"
 
 - name: Update GRUB timeout for easier console recovery and debugging           
+  become: yes
   lineinfile:
     regexp: '^GRUB_TIMEOUT=.*$'
     line: "GRUB_TIMEOUT={{ grsecurity_install_grub_timeout }}"

--- a/roles/install-grsec-kernel/tasks/packages.yml
+++ b/roles/install-grsec-kernel/tasks/packages.yml
@@ -3,7 +3,7 @@
   copy:
     src: "{{ grsecurity_install_deb_package }}"
     dest: "{{ grsecurity_install_download_dir }}/{{ grsecurity_install_deb_package | basename }}"
-  when: grsecurity_install_desired_kernel_version != ansible_kernel
+  register: grsecurity_install_copy_deb_package_result
 
 - name: Install PaX utilities.
   apt:
@@ -21,7 +21,8 @@
     # about overwriting lib modules. A subsequent task will validate
     # that a grsec-patched kernel is actually running.
     dpkg_options: skip-same-version,force-confdef,force-confold
-  when: grsecurity_install_desired_kernel_version != ansible_kernel
+  when: grsecurity_install_copy_deb_package_result.changed or
+        grsecurity_install_force_install == true
   notify:
     - Update GRUB.
     - Update host facts.

--- a/roles/install-grsec-kernel/tasks/packages.yml
+++ b/roles/install-grsec-kernel/tasks/packages.yml
@@ -2,7 +2,7 @@
 - name: Copy kernel image deb package.
   copy:
     src: "{{ grsecurity_install_deb_package }}"
-    dest: "/root/{{ grsecurity_install_deb_package | basename }}"
+    dest: "{{ grsecurity_install_download_dir }}/{{ grsecurity_install_deb_package | basename }}"
   when: grsecurity_install_desired_kernel_version != ansible_kernel
 
 - name: Install PaX utilities.
@@ -16,7 +16,7 @@
 
 - name: Install grsecurity-patched kernel deb package.
   apt:
-    deb: /root/{{ grsecurity_install_deb_package | basename }}
+    deb: "{{ grsecurity_install_download_dir }}/{{ grsecurity_install_deb_package | basename }}"
     # Adding --skip-same-version to avoid an interactive dpkg prompt
     # about overwriting lib modules. A subsequent task will validate
     # that a grsec-patched kernel is actually running.

--- a/roles/install-grsec-kernel/tasks/packages.yml
+++ b/roles/install-grsec-kernel/tasks/packages.yml
@@ -1,11 +1,13 @@
 ---
 - name: Copy kernel image deb package.
+  become: yes
   copy:
     src: "{{ grsecurity_install_deb_package }}"
     dest: "{{ grsecurity_install_download_dir }}/{{ grsecurity_install_deb_package | basename }}"
   register: grsecurity_install_copy_deb_package_result
 
 - name: Install PaX utilities.
+  become: yes
   apt:
     name: "{{ item }}"
     state: present
@@ -15,6 +17,7 @@
     - "{{ ['paxctl'] if grsecurity_install_set_paxctl_flags else [] }}"
 
 - name: Install grsecurity-patched kernel deb package.
+  become: yes
   apt:
     deb: "{{ grsecurity_install_download_dir }}/{{ grsecurity_install_deb_package | basename }}"
     # Adding --skip-same-version to avoid an interactive dpkg prompt

--- a/roles/install-grsec-kernel/tasks/paxctl.yml
+++ b/roles/install-grsec-kernel/tasks/paxctl.yml
@@ -4,6 +4,7 @@
   # that could leave a system unbootable if versions change.
 - name: Make the required grub paxctl changes.
   command: paxctl -Cpm {{ item }}
+  become: yes
   with_items:
     - /usr/sbin/grub-probe
     - /usr/sbin/grub-mkdevicemap
@@ -17,10 +18,12 @@
   # with "/usr/bin/python2.7: Text file busy". By using
   # `raw`, only localhost's ssh and the remote's sh are used.
   raw: paxctl -c /usr/bin/python2.7
+  become: yes
   when: ansible_distribution == "Debian"
 
 - name: Disable memprotect on python2.7.
   raw: paxctl -m /usr/bin/python2.7
+  become: yes
   register: disable_memprotect_python_result
   changed_when: '"converted" in disable_memprotect_python_result.stdout'
   when: ansible_distribution == "Debian"

--- a/roles/install-grsec-kernel/tasks/set_host_facts.yml
+++ b/roles/install-grsec-kernel/tasks/set_host_facts.yml
@@ -17,3 +17,13 @@
   # Intentionally using key=value syntax to support Ansible v1 and v2,
   # which have different escaping rules for the regex_replace filter.
   set_fact: grsecurity_install_desired_kernel_version="{{ grsecurity_install_deb_package | basename | regex_replace('^linux-image-([\d\.]+-grsec)_.*$', '\\1') }}"
+
+  # Sanity check to ensure that the regex substitution above worked.
+- name: Fail if desired kernel version as not found.
+  fail:
+    msg: >
+      Could not find desired grsecurity kernel version. Check the filepath
+      specified by `grsecurity_install_deb_package` and make sure it matches
+      the regular expression 'linux-image-[\d.]+-grsec'.
+  when: grsecurity_install_desired_kernel_version is not defined or
+        grsecurity_install_desired_kernel_version == ''

--- a/roles/install-grsec-kernel/tasks/set_host_facts.yml
+++ b/roles/install-grsec-kernel/tasks/set_host_facts.yml
@@ -10,7 +10,8 @@
       Define the variable 'grsecurity_install_deb_package'
       with the filepath to the local .deb package,
       then rerun the playbook.
-  when: grsecurity_install_deb_package is not defined
+  when: grsecurity_install_deb_package is not defined or
+        grsecurity_install_deb_package == ''
 
 - name: Set desired kernel version as host fact.
   # Intentionally using key=value syntax to support Ansible v1 and v2,


### PR DESCRIPTION
The use of sudo/become throughout the build and install roles is now much more carefully managed. In particular, running the build role with sudo/become enabled will now cause the role to fail (see #31) with an informative, if slightly admonishing, message.

Also adds proper namespacing for default role vars, e.g. `grub_timeout` -> `grsecurity_install_grub_timeout`, which is consistent with Ansible best practices. In particular there was an issue where the var `grsecurity_deb_package` was used by both the build and install roles, but referred to different concepts. (In the build role, it meant the basename on disk that was built and should be fetched back; in the install role, it meant the path to the deb file on the Ansible controller.)

Whereas #45 handled the default var namespacing in the install role, these changes finish the job by referencing the build role.

Closes #31.
