### PR TITLE
Make sure Vagrant boxes are downloaded over HTTPS

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,6 +7,7 @@ Vagrant.configure("2") do |config|
     # Using Ubuntu 15.04 rather than 14.04 LTS due to a bug in kernel-package.
     # See #30 for details: https://github.com/freedomofpress/grsec/issues/30
     build.vm.box = "ubuntu/vivid64"
+    build.vm.box_url = "https://cloud-images.ubuntu.com/vagrant/vivid/current/vivid-server-cloudimg-amd64-vagrant-disk1.box"
     build.vm.hostname = "grsec-build"
 
     build.vm.provision :ansible do |ansible|
@@ -37,6 +38,7 @@ Vagrant.configure("2") do |config|
     # install.vm.box = "debian/jessie64"
     # install.vm.box = "ubuntu/vivid64"
     install.vm.box = "ubuntu/trusty64"
+    install.vm.box_url = "https://cloud-images.ubuntu.com/vagrant/trusty/current/trusty-server-cloudimg-amd64-vagrant-disk1.box"
     install.vm.hostname = "grsec-install"
     # If grsec install works, the shared folder mount will fail.
     # Set `disabled: true` below to prevent the error post-install.


### PR DESCRIPTION
Original commit by @ecneladis, rebased by @conorsch on top of master
to standardize on vivid64, rather than trusty64, for the build host.

See #37 for explanation of dodgy HTTPS URLs, and #30/#32 for discussion
of vivid vs trusty.

Conflicts:
    Vagrantfile
