### PR TITLE
GPG verification done right

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -207,14 +207,14 @@ cp ubuntu-trusty/debian/control-scripts/headers-postinst ubuntu-package/pkg/head
 Verify the digital signature for Grsecurity.
 
 ```
-gpg --verify grsecurity-3.0-3.14.21-201410131959.patch.sig
+gpg --verify grsecurity-3.0-3.14.21-201410131959.patch.sig grsecurity-3.0-3.14.21-201410131959.patch
 ```
 
 Verify the digital signature for the Linux kernel.
 
 ```
 unxz linux-3.14.21.tar.xz
-gpg --verify linux-3.14.21.tar.sign
+gpg --verify linux-3.14.21.tar.sign linux-3.14.21.tar
 ```
 
 Do not move on to the next step until you have successfully verified both

--- a/roles/build-grsec-kernel/tasks/fetch_linux_kernel_source.yml
+++ b/roles/build-grsec-kernel/tasks/fetch_linux_kernel_source.yml
@@ -13,6 +13,9 @@
     dest: "{{ grsecurity_build_download_directory }}"
   register: linux_source_checksums
 
+  # The "sha256sums.asc" file is a signed file, so the one-argument format
+  # to gpg is correct. Compare with the `gpg --verify` tasks in the
+  # verify.yml task list, some of which must use the two-arg format.
 - name: Verify GPG signature on SHA256 checksum file.
   command: gpg --verify {{ linux_source_checksums.dest }}
   changed_when: false

--- a/roles/build-grsec-kernel/tasks/verify.yml
+++ b/roles/build-grsec-kernel/tasks/verify.yml
@@ -8,12 +8,27 @@
     xz --decompress {{ grsecurity_build_download_directory }}/{{ linux_tarball_filename }}
     creates="{{ grsecurity_build_download_directory }}/{{ linux_tarball_filename|regex_replace('(.*)\\.xz$', '\\1') }}"
 
+  # From the gpg manpage for the --verify option:
+  #
+  #   With  more than 1 argument, the first should be a detached signature
+  #   and the remaining files ake [sic] up the the signed data.
+  #
+  # Therefore we must provide two arguments to the gpg command to ensure verification,
+  # the first being the detached signature file and the second being the file whose
+  # integrity we wish to verify.
 - name: Verify Linux tarball GPG signature.
-  command: gpg --verify {{ grsecurity_build_download_directory }}/{{ linux_tarball_signature_filename }}
+  command: >
+    gpg --verify
+    {{ grsecurity_build_download_directory }}/{{ linux_tarball_signature_filename }}
+    {{ grsecurity_build_download_directory }}/{{ linux_tarball_filename }}
   changed_when: false
 
+  # As above, use the two-arg format when calling `gpg --verify`.
 - name: Verify grsecurity patch GPG signature.
-  command: gpg --verify {{ grsecurity_build_download_directory }}/{{ grsecurity_signature_filename }}
+  command: >
+    gpg --verify
+    {{ grsecurity_build_download_directory }}/{{ grsecurity_signature_filename }}
+    {{ grsecurity_build_download_directory }}/{{ grsecurity_patch_filename }}
   changed_when: false
 
 - name: Register current release tag for Ubuntu overlay.


### PR DESCRIPTION
There's a documented, but easy-to-miss requirement for `gpg --verify` commands, stipulating that both the signature file and the filename to be verified should be specified on the command line when using a detached signature file. That's the case in several of the verification tasks for the build role. Updated and applied liberal comments for posterity.
