### PR TITLE
Smarter handling of dynamic vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,11 @@ grsecurity_build_deb_package: >-
 # Using ccache can dramatically speed up subsequent builds of the
 # same kernel source. Disable if you plan to build only once.
 grsecurity_build_use_ccache: true
+
+# Credentials for downloading the grsecurity "stable" pages. Requires subscription.
+# The "test" patches do not require authentication or a subscription.
+grsecurity_build_download_username: ''
+grsecurity_build_download_password: ''
 ```
 
 ### install-grsec-kernel

--- a/examples/build-grsecurity-kernel-stable.yml
+++ b/examples/build-grsecurity-kernel-stable.yml
@@ -2,13 +2,13 @@
 - name: Build Linux kernel with grsecurity stable patches.
   hosts: grsec-build
   vars_prompt:
-    - name: grsecurity_download_username
+    - name: grsecurity_build_download_username
       prompt: "Username for grsecurity HTTP auth"
       # Warning: setting `private: no` for username entry
       # should cause the entered text to echo back, but
       # won't work when provisioning with Vagrant. See here:
       # https://github.com/mitchellh/vagrant/issues/2924
-    - name: grsecurity_download_password
+    - name: grsecurity_build_download_password
       prompt: "Password for grsecurity HTTP auth"
   roles:
     - role: build-grsec-metapackage

--- a/examples/build-grsecurity-kernel-stable.yml
+++ b/examples/build-grsecurity-kernel-stable.yml
@@ -15,5 +15,5 @@
       tags: metapackage
 
     - role: build-grsec-kernel
-      grsecurity_patch_type: stable
+      grsecurity_build_patch_type: stable
       tags: kernel

--- a/examples/build-grsecurity-kernel-test.yml
+++ b/examples/build-grsecurity-kernel-test.yml
@@ -3,5 +3,5 @@
   hosts: grsec-build
   roles:
     - role: build-grsec-kernel
-      grsecurity_patch_type: test
+      grsecurity_build_patch_type: test
       tags: kernel

--- a/roles/build-grsec-kernel/defaults/main.yml
+++ b/roles/build-grsec-kernel/defaults/main.yml
@@ -33,3 +33,8 @@ grsecurity_build_deb_package: >-
 # Using ccache can dramatically speed up subsequent builds of the
 # same kernel source. Disable if you plan to build only once.
 grsecurity_build_use_ccache: true
+
+# Credentials for downloading the grsecurity "stable" pages. Requires subscription.
+# The "test" patches do not require authentication or a subscription.
+grsecurity_build_download_username: ''
+grsecurity_build_download_password: ''

--- a/roles/build-grsec-kernel/library/grsecurity_urls.py
+++ b/roles/build-grsec-kernel/library/grsecurity_urls.py
@@ -64,9 +64,10 @@ class LinuxKernelURLs():
             linux_kernel_version=self.linux_kernel_version,
             linux_major_version=self.linux_major_version,
             linux_tarball_filename=self.linux_tarball_filename,
+            linux_tarball_xz_filename=self.linux_tarball_xz_filename,
             linux_tarball_signature_filename=self.linux_tarball_signature_filename,
             linux_tarball_signature_url=self.linux_tarball_signature_url,
-            linux_tarball_url=self.linux_tarball_url,
+            linux_tarball_xz_url=self.linux_tarball_xz_url,
             )
 
 
@@ -82,12 +83,15 @@ class LinuxKernelURLs():
 
     @property
     def linux_tarball_filename(self):
-        return "linux-{}.tar.xz".format(self.linux_kernel_version)
-
+        return "linux-{}.tar".format(self.linux_kernel_version)
 
     @property
-    def linux_tarball_url(self):
-        return urljoin(self.linux_base_url, self.linux_tarball_filename)
+    def linux_tarball_xz_filename(self):
+        return "{}.xz".format(self.linux_tarball_filename)
+
+    @property
+    def linux_tarball_xz_url(self):
+        return urljoin(self.linux_base_url, self.linux_tarball_xz_filename)
 
 
     @property

--- a/roles/build-grsec-kernel/tasks/fetch_grsecurity_files.yml
+++ b/roles/build-grsec-kernel/tasks/fetch_grsecurity_files.yml
@@ -3,12 +3,12 @@
   get_url:
       url: "{{ grsecurity_patch_url  }}"
       dest: "{{ grsecurity_build_download_directory }}/{{ grsecurity_patch_filename }}"
-      url_username: "{{ grsecurity_build_download_username | default('') }}"
-      url_password: "{{ grsecurity_build_download_password | default('') }}"
+      url_username: "{{ grsecurity_build_download_username }}"
+      url_password: "{{ grsecurity_build_download_password }}"
 
 - name: Fetch grsecurity signature.
   get_url:
       url: "{{ grsecurity_signature_url  }}"
       dest: "{{ grsecurity_build_download_directory }}/{{ grsecurity_signature_filename }}"
-      url_username: "{{ grsecurity_build_download_username | default('') }}"
-      url_password: "{{ grsecurity_build_download_password | default('') }}"
+      url_username: "{{ grsecurity_build_download_username }}"
+      url_password: "{{ grsecurity_build_download_password }}"

--- a/roles/build-grsec-kernel/tasks/fetch_grsecurity_files.yml
+++ b/roles/build-grsec-kernel/tasks/fetch_grsecurity_files.yml
@@ -3,12 +3,12 @@
   get_url:
       url: "{{ grsecurity_patch_url  }}"
       dest: "{{ grsecurity_build_download_directory }}/{{ grsecurity_patch_filename }}"
-      url_username: "{{ grsecurity_download_username | default('') }}"
-      url_password: "{{ grsecurity_download_password | default('') }}"
+      url_username: "{{ grsecurity_build_download_username | default('') }}"
+      url_password: "{{ grsecurity_build_download_password | default('') }}"
 
 - name: Fetch grsecurity signature.
   get_url:
       url: "{{ grsecurity_signature_url  }}"
       dest: "{{ grsecurity_build_download_directory }}/{{ grsecurity_signature_filename }}"
-      url_username: "{{ grsecurity_download_username | default('') }}"
-      url_password: "{{ grsecurity_download_password | default('') }}"
+      url_username: "{{ grsecurity_build_download_username | default('') }}"
+      url_password: "{{ grsecurity_build_download_password | default('') }}"

--- a/roles/build-grsec-kernel/tasks/fetch_linux_kernel_source.yml
+++ b/roles/build-grsec-kernel/tasks/fetch_linux_kernel_source.yml
@@ -2,7 +2,7 @@
 - name: Create directory for downloaded files.
   file:
     state: directory
-    dest: "{{ grsecurity_build_download_directory }}"
+    dest: "{{ grsecurity_build_download_directory }}/"
     owner: "{{ ansible_ssh_user }}"
     group: "{{ ansible_ssh_user }}"
     mode: "0755"
@@ -10,7 +10,7 @@
 - name: Fetch SHA256 checksums for Linux source files.
   get_url:
     url: "{{ linux_checksums_url }}"
-    dest: "{{ grsecurity_build_download_directory }}"
+    dest: "{{ grsecurity_build_download_directory }}/"
   register: linux_source_checksums
 
   # The "sha256sums.asc" file is a signed file, so the one-argument format
@@ -36,4 +36,4 @@
 - name: Fetch Linux kernel tarball signature file.
   get_url:
       url: "{{ linux_tarball_signature_url }}"
-      dest: "{{ grsecurity_build_download_directory }}"
+      dest: "{{ grsecurity_build_download_directory }}/"

--- a/roles/build-grsec-kernel/tasks/fetch_linux_kernel_source.yml
+++ b/roles/build-grsec-kernel/tasks/fetch_linux_kernel_source.yml
@@ -22,15 +22,15 @@
 
 - name: Read checksum for kernel tarball.
   shell: >
-    grep {{ linux_tarball_filename | quote }}
+    grep {{ linux_tarball_xz_filename | quote }}
     {{ linux_source_checksums.dest | quote }} | cut -d' ' -f1
   changed_when: false
   register: linux_tarball_checksum
 
 - name: Fetch Linux kernel tarball.
   get_url:
-      url: "{{ linux_tarball_url }}"
-      dest: "{{ grsecurity_build_download_directory }}/{{ linux_tarball_filename }}"
+      url: "{{ linux_tarball_xz_url }}"
+      dest: "{{ grsecurity_build_download_directory }}/{{ linux_tarball_xz_filename }}"
       sha256sum: "{{ linux_tarball_checksum.stdout }}"
 
 - name: Fetch Linux kernel tarball signature file.

--- a/roles/build-grsec-kernel/tasks/prepare_source_directory.yml
+++ b/roles/build-grsec-kernel/tasks/prepare_source_directory.yml
@@ -8,7 +8,7 @@
   unarchive:
     copy: no
     src: "{{ grsecurity_build_download_directory }}/linux-{{ linux_kernel_version }}.tar"
-    dest: "{{ grsecurity_build_download_directory }}"
+    dest: "{{ grsecurity_build_download_directory }}/"
 
 - name: Apply grsecurity patch.
   patch:

--- a/roles/build-grsec-kernel/tasks/verify.yml
+++ b/roles/build-grsec-kernel/tasks/verify.yml
@@ -2,11 +2,10 @@
 - name: Extract Linux tarball (.xz -> .tar).
   # Can't use the `unarchive` module here, because it destroys
   # the intermediary .tar file, which we need to verify the GPG sig.
-  # Intentionally using key=value syntax to support Ansible v1 and v2,
-  # which have different escaping rules for the regex_replace filter.
   command: >
-    xz --decompress {{ grsecurity_build_download_directory }}/{{ linux_tarball_filename }}
-    creates="{{ grsecurity_build_download_directory }}/{{ linux_tarball_filename|regex_replace('(.*)\\.xz$', '\\1') }}"
+    xz --decompress {{ grsecurity_build_download_directory }}/{{ linux_tarball_xz_filename }}
+  args:
+    creates: "{{ grsecurity_build_download_directory }}/{{ linux_tarball_filename }}"
 
   # From the gpg manpage for the --verify option:
   #

--- a/roles/install-grsec-kernel/filter_plugins/extract_kernel_version.py
+++ b/roles/install-grsec-kernel/filter_plugins/extract_kernel_version.py
@@ -1,0 +1,25 @@
+import re
+
+from ansible import errors
+
+
+def extract_kernel_version(deb_package):
+    """
+    Read filename for linux-image Debian package and return only
+    the kernel version it would install, e.g. "4.4.4-grsec".
+    """
+
+    try:
+        results = re.findall(r'^linux-image-([\d.]+-grsec)', deb_package)[0]
+    except IndexError:
+        msg = ("Could not determine desired kernel version in '{}', make sure it matches "
+              "the regular expression '^linux-image-[\d.]+-grsec'").format(deb_package)
+        raise errors.AnsibleFilterError(msg)
+
+    return results
+
+class FilterModule(object):
+    def filters(self):
+        return {
+            'extract_kernel_version': extract_kernel_version
+        }

--- a/roles/install-grsec-kernel/filter_plugins/extract_kernel_version.py
+++ b/roles/install-grsec-kernel/filter_plugins/extract_kernel_version.py
@@ -1,3 +1,4 @@
+import os
 import re
 
 from ansible import errors
@@ -9,6 +10,8 @@ def extract_kernel_version(deb_package):
     the kernel version it would install, e.g. "4.4.4-grsec".
     """
 
+    # Convert to basename in case the filter call was not prefixed with '|basename'.
+    deb_package = os.path.basename(deb_package)
     try:
         results = re.findall(r'^linux-image-([\d.]+-grsec)', deb_package)[0]
     except IndexError:
@@ -17,6 +20,7 @@ def extract_kernel_version(deb_package):
         raise errors.AnsibleFilterError(msg)
 
     return results
+
 
 class FilterModule(object):
     def filters(self):

--- a/roles/install-grsec-kernel/tasks/set_host_facts.yml
+++ b/roles/install-grsec-kernel/tasks/set_host_facts.yml
@@ -14,11 +14,10 @@
         grsecurity_install_deb_package == ''
 
 - name: Set desired kernel version as host fact.
-  # Intentionally using key=value syntax to support Ansible v1 and v2,
-  # which have different escaping rules for the regex_replace filter.
-  set_fact: grsecurity_install_desired_kernel_version="{{ grsecurity_install_deb_package | basename | regex_replace('^linux-image-([\d\.]+-grsec)_.*$', '\\1') }}"
+  set_fact:
+    grsecurity_install_desired_kernel_version: "{{ grsecurity_install_deb_package | extract_kernel_version }}"
 
-  # Sanity check to ensure that the regex substitution above worked.
+  # Sanity check to ensure that the filter above worked.
 - name: Fail if desired kernel version as not found.
   fail:
     msg: >


### PR DESCRIPTION
Mostly this is cleanup of the too-hasty #56. The new two-arg form of the `gpg --verify` commands requires references to both the `.tar` and `.tar.xz` versions of the Linux source. Since the build role already uses a Python module to assemble dynamic vars, let's create new vars in there so they're accessible to the whole role.

Major benefit: we can delete use of the `regex_replace` filter, which has become troublesome to maintain, since Ansible v1 and v2 [require different escaping styles](https://docs.ansible.com/ansible/porting_guide_2.0.html) when using that filter. Similarly, we can delete that filter in the install role, using instead full Python in a custom filter.
