### PR TITLE
Adds libssl-dev package to Ubuntu installations

### DIFF
--- a/roles/build-grsec-kernel/vars/Ubuntu.yml
+++ b/roles/build-grsec-kernel/vars/Ubuntu.yml
@@ -7,5 +7,6 @@ apt_packages:
   - git-core
   - kernel-package
   - libncurses5-dev
+  - libssl-dev
   - make
   - python-requests


### PR DESCRIPTION
A very small change to ensure that the `libssl-dev` package is present when building under vivid64, which is the default. Installing this package allows the default setup of building test patches under vivid64 to complete without error.

Closes #55. Related: #19, #33.
