### PR TITLE
Makes reboot optional in install role

### DIFF
--- a/roles/install-grsec-kernel/defaults/main.yml
+++ b/roles/install-grsec-kernel/defaults/main.yml
@@ -23,3 +23,7 @@ grsecurity_install_download_dir: /usr/local/src
 # for the deb file is the same. If you want to reinstall the same kernel version,
 # for example while developing a new kernel config, set this to true.
 grsecurity_install_force_install: false
+
+# If the target host is remote, assume that rebooting is desired, but don't
+# reboot if we're installing on localhost.
+grsecurity_install_reboot: "{{ false if ansible_connection == 'local' else true }}"

--- a/roles/install-grsec-kernel/tasks/main.yml
+++ b/roles/install-grsec-kernel/tasks/main.yml
@@ -9,5 +9,13 @@
 - include: grub_config.yml
 
 - include: validate_install.yml
-  when: grsecurity_install_desired_kernel_version != ansible_kernel
+  when: grsecurity_install_desired_kernel_version != ansible_kernel and
+        grsecurity_install_reboot == true
 
+- name: Display message about required reboot.
+  debug:
+    msg: >-
+      Installed grsecurity-patched kernel version '{{ grsecurity_install_desired_kernel_version }}'.
+      You must reboot the host to load the new kernel.
+  when: grsecurity_install_desired_kernel_version != ansible_kernel and
+        grsecurity_install_reboot == false


### PR DESCRIPTION
Ran into the need to prevent a reboot while installing on localhost. In general it's a good idea to have the reboot be optional. It's still on by default, but can be skipped. When installing on localhost, the reboot will be skipped by default, but that's configurable too.

Simply set `grsecurity_install_reboot: false` to avoid the automatic reboot.
