### PR TITLE
Updates elevated privileges logic for Ansible v2

### DIFF
--- a/roles/build-grsec-kernel/tasks/fetch_linux_kernel_source.yml
+++ b/roles/build-grsec-kernel/tasks/fetch_linux_kernel_source.yml
@@ -3,8 +3,6 @@
   file:
     state: directory
     dest: "{{ grsecurity_build_download_directory }}/"
-    owner: "{{ ansible_ssh_user }}"
-    group: "{{ ansible_ssh_user }}"
     mode: "0755"
 
 - name: Fetch SHA256 checksums for Linux source files.

--- a/roles/build-grsec-kernel/tasks/main.yml
+++ b/roles/build-grsec-kernel/tasks/main.yml
@@ -1,13 +1,13 @@
 ---
 - name: Stop if running with elevated privileges.
   fail:
-    msg: >
+    msg: >-
       WARNING! You should not compile the Linux kernel with
       superuser privileges. Doing so may create an unbootable
       system. See Greg Kroah-Hartman's Linux Kernel in a Nutshell
       for anecdotes about how doing so has broken systems
       in the past: http://www.kroah.com/lkn/
-  when: ansible_ssh_user == 'root' or ansible_user_id == 'root'
+  when: ansible_env.USER == 'root'
 
   # Install packages before fetching dynamic URLs, since python-requests
   # is required by the URL-fetching Ansible module.


### PR DESCRIPTION
Ansible v2.0.2 was released two days ago, and causes the build role to fail. The changes presented here are rather minor, and I've confirmed that they work with Ansible versions:
- 1.9.4
- 2.0.1
- 2.0.2

The build role will still abort if run with sudo privileges, and display a message explaining the rationale. Further into the future we may wish to force `become: no` on the tasks we don't want elevated privileges for, rather than fail if sudo is enabled, but for now the approach is both reliable and informative.

Closes #62.
