### PR TITLE
Supports custom kernel config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,10 @@ grsecurity_build_patch_type: test
 # "config-{{ grsecurity_build_strategy }}" when searching for files.
 grsecurity_build_strategy: manual
 
+# Premade config file for use during compilation. Useful if you've previously
+# run `make menuconfig` and want to restore the custom settings.
+grsecurity_build_custom_config: ''
+
 # When building for installation on Ubuntu, one should include the
 # overlay to ensure that Ubuntu-specific options for AppArmor work.
 # Honestly this needs a lot more testing, so leaving off by default.

--- a/roles/build-grsec-kernel/defaults/main.yml
+++ b/roles/build-grsec-kernel/defaults/main.yml
@@ -12,6 +12,10 @@ grsecurity_build_patch_type: test
 # "config-{{ grsecurity_build_strategy }}" when searching for files.
 grsecurity_build_strategy: manual
 
+# Premade config file for use during compilation. Useful if you've previously
+# run `make menuconfig` and want to restore the custom settings.
+grsecurity_build_custom_config: ''
+
 # When building for installation on Ubuntu, one should include the
 # overlay to ensure that Ubuntu-specific options for AppArmor work.
 # Honestly this needs a lot more testing, so leaving off by default.

--- a/roles/build-grsec-kernel/tasks/configure.yml
+++ b/roles/build-grsec-kernel/tasks/configure.yml
@@ -1,8 +1,13 @@
 ---
 - name: Copy baseline grsecurity config template.
   copy:
-    src: config-{{ grsecurity_build_strategy }}
+    src: "{{ item }}"
     dest: "{{ grsecurity_build_linux_source_directory }}/.config"
+  # Prioritize custom config file, if specified. Fallback to prebuilt
+  # config that ships with the role.
+  with_first_found:
+    - "{{ grsecurity_build_custom_config }}"
+    - config-{{ grsecurity_build_strategy }}
 
 - name: Ensure any new options are updated with defaults.
   command: make olddefconfig

--- a/roles/build-grsec-kernel/tasks/main.yml
+++ b/roles/build-grsec-kernel/tasks/main.yml
@@ -43,8 +43,10 @@
 
 - include: configure.yml
   tags: configure
-  when: grsecurity_build_strategy != "manual"
+  when: grsecurity_build_strategy != "manual" or
+        grsecurity_build_custom_config != ''
 
 - include: compile.yml
   tags: compile
-  when: grsecurity_build_strategy != "manual"
+  when: grsecurity_build_strategy != "manual" or
+        grsecurity_build_custom_config != ''


### PR DESCRIPTION
Rather than supporting only a fully manual configuration, requiring interactive use of `make menuconfig` or similar prior to compiling, let's allow admins to provide a prebaked config file for use during compilation. The approach used here is backwards compatible with the strategy used to reference starter configs already shipping with the role. Via `with_first_found` and `include_copy`, a custom config file set via `grsecurity_build_custom_config` will override the starter configs.

Permits fully unattended builds of custom kernels via a single var override. Very useful for repeated uses of the role for maintaining a stable config, where the kernel config is host- or site-specific, and therefore not included in the role itself. The newest applicable kernel sources and grsecurity patches will be used on each run, and newly added kernel config options will receive default values value `make olddefconfig`.

Closes #48.
