### PR TITLE
Supports custom compilation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,23 @@ grsecurity_build_deb_package: >-
 # same kernel source. Disable if you plan to build only once.
 grsecurity_build_use_ccache: true
 
+# Specify targets for make-kpkg, e.g. kernel_image, kernel_headers, or binary.
+# See `man make-kpkg` for details.
+grsecurity_build_kpkg_targets:
+  - kernel_image
+
+# The command to run to perform the compilation. Does not include environment
+# variables, such as PATH munging for ccache and setting workers to number of VCPUs.
+grsecurity_build_compile_command:
+  fakeroot make-kpkg
+  --revision 10.00.{{ grsecurity_build_strategy }}
+  {% if grsecurity_build_include_ubuntu_overlay == true %} --overlay-dir=../ubuntu-package {% endif %}
+  --initrd {{ grsecurity_build_kpkg_targets|join(' ') }}
+
+# Whether built .deb files should be fetched back to the Ansible controller.
+# Useful when compiling remotely, but not so much on a local workstation.
+grsecurity_build_fetch_packages: true
+
 # Credentials for downloading the grsecurity "stable" pages. Requires subscription.
 # The "test" patches do not require authentication or a subscription.
 grsecurity_build_download_username: ''

--- a/roles/build-grsec-kernel/defaults/main.yml
+++ b/roles/build-grsec-kernel/defaults/main.yml
@@ -38,6 +38,15 @@ grsecurity_build_deb_package: >-
 # same kernel source. Disable if you plan to build only once.
 grsecurity_build_use_ccache: true
 
+grsecurity_build_kpkg_targets:
+  - kernel_image
+
+grsecurity_build_compile_command:
+  fakeroot make-kpkg
+  --revision 10.00.{{ grsecurity_build_strategy }}
+  {% if grsecurity_build_include_ubuntu_overlay == true %} --overlay-dir=../ubuntu-package {% endif %}
+  --initrd {{ grsecurity_build_kpkg_targets|join(' ') }}
+
 # Credentials for downloading the grsecurity "stable" pages. Requires subscription.
 # The "test" patches do not require authentication or a subscription.
 grsecurity_build_download_username: ''

--- a/roles/build-grsec-kernel/defaults/main.yml
+++ b/roles/build-grsec-kernel/defaults/main.yml
@@ -47,6 +47,10 @@ grsecurity_build_compile_command:
   {% if grsecurity_build_include_ubuntu_overlay == true %} --overlay-dir=../ubuntu-package {% endif %}
   --initrd {{ grsecurity_build_kpkg_targets|join(' ') }}
 
+# Whether built .deb files should be fetched back to the Ansible controller.
+# Useful when compiling remotely, but not so much on a local workstation.
+grsecurity_build_fetch_packages: true
+
 # Credentials for downloading the grsecurity "stable" pages. Requires subscription.
 # The "test" patches do not require authentication or a subscription.
 grsecurity_build_download_username: ''

--- a/roles/build-grsec-kernel/defaults/main.yml
+++ b/roles/build-grsec-kernel/defaults/main.yml
@@ -55,6 +55,9 @@ grsecurity_build_compile_command:
 # Useful when compiling remotely, but not so much on a local workstation.
 grsecurity_build_fetch_packages: true
 
+# Where fetched packages should be placed. Defaults to adjacent to playbook.
+grsecurity_build_fetch_packages_dest: "./"
+
 # Credentials for downloading the grsecurity "stable" pages. Requires subscription.
 # The "test" patches do not require authentication or a subscription.
 grsecurity_build_download_username: ''

--- a/roles/build-grsec-kernel/defaults/main.yml
+++ b/roles/build-grsec-kernel/defaults/main.yml
@@ -38,9 +38,13 @@ grsecurity_build_deb_package: >-
 # same kernel source. Disable if you plan to build only once.
 grsecurity_build_use_ccache: true
 
+# Specify targets for make-kpkg, e.g. kernel_image, kernel_headers, or binary.
+# See `man make-kpkg` for details.
 grsecurity_build_kpkg_targets:
   - kernel_image
 
+# The command to run to perform the compilation. Does not include environment
+# variables, such as PATH munging for ccache and setting workers to number of VCPUs.
 grsecurity_build_compile_command:
   fakeroot make-kpkg
   --revision 10.00.{{ grsecurity_build_strategy }}

--- a/roles/build-grsec-kernel/tasks/compile.yml
+++ b/roles/build-grsec-kernel/tasks/compile.yml
@@ -1,10 +1,12 @@
 ---
+- name: Display the build command to be used for compilation.
+  debug:
+    msg: >-
+      Now building via command:
+      `{{ grsecurity_build_compile_command }}`
+
 - name: Build the grsecurity-patched kernel.
-  command: >
-    fakeroot make-kpkg
-    --revision 10.00.{{ grsecurity_build_strategy }}
-    {% if grsecurity_build_include_ubuntu_overlay == true %} --overlay-dir=../ubuntu-package {% endif %}
-    --initrd kernel_image
+  command: "{{ grsecurity_build_compile_command }}"
   args:
     chdir: "{{ grsecurity_build_linux_source_directory }}"
   environment:

--- a/roles/build-grsec-kernel/tasks/compile.yml
+++ b/roles/build-grsec-kernel/tasks/compile.yml
@@ -25,5 +25,6 @@
   # image, headers, src, manual, etc.
   with_fileglob:
     - "{{ grsecurity_build_download_directory }}/linux-*-{{ linux_kernel_version }}-grsec*.deb"
+  when: grsecurity_build_fetch_packages == true
   tags:
     - fetch

--- a/roles/build-grsec-kernel/tasks/compile.yml
+++ b/roles/build-grsec-kernel/tasks/compile.yml
@@ -18,8 +18,7 @@
 - name: Fetch built kernel package back to localhost.
   fetch:
     src: "{{ grsecurity_build_download_directory }}/{{ grsecurity_build_deb_package }}"
-    dest: ./
-    fail_on_missing: yes
+    dest: "{{ grsecurity_build_fetch_packages_dest }}"
     flat: yes
   # Intentionally fuzzy fileglob to support fetching back multiple build targets, e.g.
   # image, headers, src, manual, etc.

--- a/roles/build-grsec-kernel/tasks/compile.yml
+++ b/roles/build-grsec-kernel/tasks/compile.yml
@@ -21,5 +21,9 @@
     dest: ./
     fail_on_missing: yes
     flat: yes
+  # Intentionally fuzzy fileglob to support fetching back multiple build targets, e.g.
+  # image, headers, src, manual, etc.
+  with_fileglob:
+    - "{{ grsecurity_build_download_directory }}/linux-*-{{ linux_kernel_version }}-grsec*.deb"
   tags:
     - fetch

--- a/roles/build-grsec-kernel/tasks/prepare_source_directory.yml
+++ b/roles/build-grsec-kernel/tasks/prepare_source_directory.yml
@@ -37,8 +37,6 @@
     msg: >
       Build environment ready. Kernel source is available in
       {{ grsecurity_build_linux_source_directory }} . Run `make menuconfig` in that
-      directory to configure the build, then `make-kpkg kernel_image`
+      directory to configure the build, then `{{ grsecurity_build_compile_command }}`
       or similar to begin compiling the kernel.
   when: grsecurity_build_strategy == "manual"
-
-

--- a/roles/install-grsec-kernel/defaults/main.yml
+++ b/roles/install-grsec-kernel/defaults/main.yml
@@ -4,6 +4,11 @@
 # fail if this var is not updated. Use the build role to create a package first.
 grsecurity_install_deb_package: ''
 
+# Secondary list var to support multiple deb packages, e.g. image, headers, src.
+# This list will be concatenated with the scalar var above when generating the
+# the list of deb packages to be installed.
+grsecurity_install_deb_packages: []
+
 # For easier console recovery and debugging, the GRUB timeout value (default: 5)
 # can be overridden here. Without a lengthier timeout, it can be very difficult
 # to get into the GRUB menu and select a working kernel to boot. Debian uses 5

--- a/roles/install-grsec-kernel/tasks/packages.yml
+++ b/roles/install-grsec-kernel/tasks/packages.yml
@@ -1,10 +1,14 @@
 ---
-- name: Copy kernel image deb package.
+- name: Copy kernel deb packages to install.
   become: yes
   copy:
-    src: "{{ grsecurity_install_deb_package }}"
-    dest: "{{ grsecurity_install_download_dir }}/{{ grsecurity_install_deb_package | basename }}"
-  register: grsecurity_install_copy_deb_package_result
+    src: "{{ item }}"
+    dest: "{{ grsecurity_install_download_dir }}/{{ item|basename }}"
+  register: grsecurity_install_copy_deb_packages_result
+  # Support both single-item and list-var format for deb packages.
+  with_flattened:
+    - ["{{ grsecurity_install_deb_package }}"]
+    - "{{ grsecurity_install_deb_packages }}"
 
 - name: Install PaX utilities.
   become: yes
@@ -19,17 +23,17 @@
 - name: Install grsecurity-patched kernel deb package.
   become: yes
   apt:
-    deb: "{{ grsecurity_install_download_dir }}/{{ grsecurity_install_deb_package | basename }}"
+    deb: "{{ grsecurity_install_download_dir }}/{{ item.item | basename }}"
     # Adding --skip-same-version to avoid an interactive dpkg prompt
     # about overwriting lib modules. A subsequent task will validate
     # that a grsec-patched kernel is actually running.
     dpkg_options: skip-same-version,force-confdef,force-confold
-  when: grsecurity_install_copy_deb_package_result.changed or
+  with_items: "{{ grsecurity_install_copy_deb_packages_result.results }}"
+  when: item.changed == true or
         grsecurity_install_force_install == true
   notify:
     - Update GRUB.
     - Update host facts.
 
-  # Force handlers to run immediatley, so grub config is updated.
+  # Force handlers to run immediately, so grub config is updated.
 - meta: flush_handlers
-


### PR DESCRIPTION
Provides a vars-based override for customizing the compilation command. The default behavior of the role is unchanged, but the explanatory messaging is now more explicit, listing an example compilation command. If additional `make-kpkg` targets are desired, they can be specified in the list var `grsecurity_build_kpkg_targets`, or the entire compile command can be set to an explicit command string.

Partially implements #64; these changes only affect the build role, and install role changes will also be necessary to close that issue out.
