### PR TITLE
Supports installation of multiple deb packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,11 @@ grsecurity_build_download_password: ''
 # fail if this var is not updated. Use the build role to create a package first.
 grsecurity_install_deb_package: ''
 
+# Secondary list var to support multiple deb packages, e.g. image, headers, src.
+# This list will be concatenated with the scalar var above when generating the
+# the list of deb packages to be installed.
+grsecurity_install_deb_packages: []
+
 # For easier console recovery and debugging, the GRUB timeout value (default: 5)
 # can be overridden here. Without a lengthier timeout, it can be very difficult
 # to get into the GRUB menu and select a working kernel to boot. Debian uses 5
@@ -172,6 +177,10 @@ grsecurity_install_download_dir: /usr/local/src
 # for the deb file is the same. If you want to reinstall the same kernel version,
 # for example while developing a new kernel config, set this to true.
 grsecurity_install_force_install: false
+
+# If the target host is remote, assume that rebooting is desired, but don't
+# reboot if we're installing on localhost.
+grsecurity_install_reboot: "{{ false if ansible_connection == 'local' else true }}"
 ```
 
 ## Further reading

--- a/examples/install-grsecurity-kernel.yml
+++ b/examples/install-grsecurity-kernel.yml
@@ -3,7 +3,13 @@
   hosts: grsec-install
   roles:
     - role: install-grsec-kernel
-      # Add the filepath to the .deb package here. The playbook will error out
+      # Add the filepaths to the .deb packages here. The playbook will error out
       # if the package can't be found. If you're referencing this playbook while it's
       # still inside the "examples" directory, you may have to precede the filename with "../".
-      # grsecurity_install_deb_package: ''
+      # grsecurity_install_deb_packages:
+      #   - ../linux-doc-4.7.6-grsec_4.7.6-grsec-10.00.Custom_all.deb
+      #   - ../linux-headers-4.7.6-grsec_4.7.6-grsec-10.00.Custom_amd64.deb
+      #   - ../linux-image-4.7.6-grsec_4.7.6-grsec-10.00.Custom_amd64.deb
+      #   - ../linux-image-4.7.6-grsec-dbg_4.7.6-grsec-10.00.Custom_amd64.deb
+      #   - ../linux-manual-4.7.6-grsec_4.7.6-grsec-10.00.Custom_all.deb
+      #   - ../linux-source-4.7.6-grsec_4.7.6-grsec-10.00.Custom_all.deb

--- a/roles/install-grsec-kernel/tasks/packages.yml
+++ b/roles/install-grsec-kernel/tasks/packages.yml
@@ -5,10 +5,7 @@
     src: "{{ item }}"
     dest: "{{ grsecurity_install_download_dir }}/{{ item|basename }}"
   register: grsecurity_install_copy_deb_packages_result
-  # Support both single-item and list-var format for deb packages.
-  with_flattened:
-    - ["{{ grsecurity_install_deb_package }}"]
-    - "{{ grsecurity_install_deb_packages }}"
+  with_items: "{{ grsecurity_install_combined_deb_packages }}"
 
 - name: Install PaX utilities.
   become: yes

--- a/roles/install-grsec-kernel/tasks/set_host_facts.yml
+++ b/roles/install-grsec-kernel/tasks/set_host_facts.yml
@@ -2,25 +2,36 @@
 - name: Get GRUB menu options as host facts.
   action: grub_menu_options
 
-  # Role requires that `grsecurity_install_deb_package` be defined.
+  # Role requires that at least one of `grsecurity_install_deb_package` or
+  # `grsecurity_install_deb_packages` be defined.
 - name: Check filename for deb package.
   fail:
-    msg: >
+    msg: >-
       No deb package specified for installation.
-      Define the variable 'grsecurity_install_deb_package'
-      with the filepath to the local .deb package,
+      Define the variable 'grsecurity_install_deb_packages'
+      with the filepaths to the local .deb packages,
       then rerun the playbook.
-  when: grsecurity_install_deb_package is not defined or
-        grsecurity_install_deb_package == ''
+  when: (grsecurity_install_deb_package is not defined or grsecurity_install_deb_package == '') and
+        (grsecurity_install_deb_packages == [] )
+
+# Since we may have multiple deb packages, first identify the `linux-image-*` package,
+# so we can extract the desired kernel version from that filename string.
+- name: Inspect deb packages for kernel image package
+  set_fact:
+    grsecurity_install_kernel_image_package: "{{ item }}"
+  when: (item|basename).startswith('linux-image')
+  with_flattened:
+    - ["{{ grsecurity_install_deb_package }}"]
+    - "{{ grsecurity_install_deb_packages }}"
 
 - name: Set desired kernel version as host fact.
   set_fact:
-    grsecurity_install_desired_kernel_version: "{{ grsecurity_install_deb_package | extract_kernel_version }}"
+    grsecurity_install_desired_kernel_version: "{{ grsecurity_install_kernel_image_package | extract_kernel_version }}"
 
   # Sanity check to ensure that the filter above worked.
 - name: Fail if desired kernel version as not found.
   fail:
-    msg: >
+    msg: >-
       Could not find desired grsecurity kernel version. Check the filepath
       specified by `grsecurity_install_deb_package` and make sure it matches
       the regular expression 'linux-image-[\d.]+-grsec'.

--- a/roles/install-grsec-kernel/tasks/set_host_facts.yml
+++ b/roles/install-grsec-kernel/tasks/set_host_facts.yml
@@ -14,15 +14,19 @@
   when: (grsecurity_install_deb_package is not defined or grsecurity_install_deb_package == '') and
         (grsecurity_install_deb_packages == [] )
 
+# Support both single-item and list-var format for deb packages, but omit the
+# default empty string var if found.
+- name: Set combined list var for deb package filepaths.
+  set_fact:
+    grsecurity_install_combined_deb_packages: "{{ (grsecurity_install_deb_packages+[grsecurity_install_deb_package])|difference(['']) }}"
+
 # Since we may have multiple deb packages, first identify the `linux-image-*` package,
 # so we can extract the desired kernel version from that filename string.
 - name: Inspect deb packages for kernel image package
   set_fact:
     grsecurity_install_kernel_image_package: "{{ item }}"
   when: (item|basename).startswith('linux-image')
-  with_flattened:
-    - ["{{ grsecurity_install_deb_package }}"]
-    - "{{ grsecurity_install_deb_packages }}"
+  with_items: "{{ grsecurity_install_combined_deb_packages }}"
 
 - name: Set desired kernel version as host fact.
   set_fact:


### PR DESCRIPTION
Currently the install role only supported installation of a single deb package, presumably the `linux-image-*.deb` package. This PR creates an additional role var for passing in a list, rather than a single filepath as a string.

If more packages are required, such as kernel-headers or kernel-src, use the `grsecurity_install_deb_packages` list var to specify all of them for installation. The remainder of the role logic remains constant. 

Together with #71, satisfies #64. 
