### PR TITLE
Resolve ansible 2.2+ deprecation for bare vars in with_items

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.deb
 spec_tests/gems/*
 spec_tests/Gemfile.lock
+*.py[cod]

--- a/roles/install-grsec-kernel/tasks/grub_config.yml
+++ b/roles/install-grsec-kernel/tasks/grub_config.yml
@@ -2,7 +2,7 @@
 - name: Find the menu title for the grsecurity kernel in GRUB config.
   set_fact:
     grub_grsecurity_menu_entry: "{{ item }}"
-  with_items: grub_menu_options
+  with_items: "{{ grub_menu_options }}"
   # Check for an exact match, right-aligned, for the target kernel version
   # currently being installed. Tested on Debian. Example string to match:
   #   Debian GNU/Linux, with Linux 3.14.54-grsec


### PR DESCRIPTION
From the following porting guide,
https://docs.ansible.com/ansible/porting_guide_2.0.html