### PR TITLE
Vagrant boxes to bento/ubuntu-14.04 for best reproducibility

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,10 +4,7 @@
 Vagrant.configure("2") do |config|
 
   config.vm.define 'grsec-build', primary: true do |build|
-    # Using Ubuntu 15.04 rather than 14.04 LTS due to a bug in kernel-package.
-    # See #30 for details: https://github.com/freedomofpress/grsec/issues/30
-    build.vm.box = "ubuntu/vivid64"
-    build.vm.box_url = "https://cloud-images.ubuntu.com/vagrant/vivid/current/vivid-server-cloudimg-amd64-vagrant-disk1.box"
+    build.vm.box = "bento/ubuntu-14.04"
     build.vm.hostname = "grsec-build"
 
     build.vm.provision :ansible do |ansible|
@@ -37,8 +34,7 @@ Vagrant.configure("2") do |config|
     # install.vm.box = "debian/wheezy64"
     # install.vm.box = "debian/jessie64"
     # install.vm.box = "ubuntu/vivid64"
-    install.vm.box = "ubuntu/trusty64"
-    install.vm.box_url = "https://cloud-images.ubuntu.com/vagrant/trusty/current/trusty-server-cloudimg-amd64-vagrant-disk1.box"
+    install.vm.box = "bento/ubuntu-14.04"
     install.vm.hostname = "grsec-install"
     # If grsec install works, the shared folder mount will fail.
     # Set `disabled: true` below to prevent the error post-install.
@@ -79,4 +75,3 @@ def available_vcpus
   # return available_vcpus / 2
   return available_vcpus
 end
-


### PR DESCRIPTION
* Since bento boxes more closely reproduce a HW SD install environment than
  official Ubuntu Vagrant images, it is preferred to use them
  (https://github.com/freedomofpress/securedrop/issues/1344#issue-161779879).
  Also, #30 was resolved, so we should be able to build in kernels in Trusty
  again, ensuring we'll be building stable kernels against the exact same
  version of glibc as is present on live SD instances.
* We confirmed that Vagrant always uses https, so the `box_url` parameter is
  not needed.

... I have one concern about the second bullet, however. And that regards the fact that I know we tested this, but can't find the conversation on Slack or in SD issues regarding it, and can't remember what all tests were performed. Sure Vagrant will choose HTTPS by default if we omit `box_url`, but will it throw an error if a MITM attacker tries to downgrade the connection to HTTP? The [relevant documentation](https://www.vagrantup.com/docs/vagrantfile/machine_settings.html) leads one to believe that might be the case. In any case, I can't read Ruby, and it might be easier to do this experimentally than look at the code. Maybe [I'll use a Vagrant VM to MITM Vagrant](https://github.com/praetorian-inc/mitm-vm). The discussion here is obviously applicable to all our work as we are heavy Vagrant users, so it seems especially worthwhile.