### PR TITLE
Default to stable2 patch since 3.14 is EOL

### DIFF
--- a/examples/build-grsecurity-kernel-stable.yml
+++ b/examples/build-grsecurity-kernel-stable.yml
@@ -15,5 +15,5 @@
       tags: metapackage
 
     - role: build-grsec-kernel
-      grsecurity_build_patch_type: stable
+      grsecurity_build_patch_type: stable2
       tags: kernel

--- a/roles/build-grsec-metapackage/defaults/main.yml
+++ b/roles/build-grsec-metapackage/defaults/main.yml
@@ -1,8 +1,8 @@
 ---
 grsec_package_name: securedrop-grsec
 grsec_build_parent_directory: /tmp/build
-grsec_kernel_version: "3.14.57"
-securedrop_version: "0.3.5"
+grsec_kernel_version: "4.4.32"
+securedrop_version: "0.3.10"
 securedrop_architecture: amd64
 
 grsec_package_name_verbose: "{{ grsec_package_name }}-{{ grsec_kernel_version }}-{{ securedrop_architecture }}"


### PR DESCRIPTION
It was announced in https://lkml.org/lkml/2016/9/11/28 that the 3.14 kernel is
at EOL, will receive no more updates, and should not be used any longer. The 4.4
kernel, with correspoding "stable2" patches should now be defaulted to, as it is
now supposed to be the most stable LTS kernel that is still receiving updates.

Also, bumps SD version to latest.