### PR TITLE
Install latest apt pkg vers, update once per hour max

### DIFF
--- a/roles/build-grsec-kernel/tasks/ccache.yml
+++ b/roles/build-grsec-kernel/tasks/ccache.yml
@@ -5,7 +5,9 @@
 - name: Install ccache.
   apt:
     name: ccache
-    state: present
+    state: latest
+    update_cache: true
+    cache_valid_time: 3600
   become: yes
 
   # Increasing the cache size from 1GB (default) to 5GB.

--- a/roles/build-grsec-kernel/tasks/fetch_ubuntu_overlay.yml
+++ b/roles/build-grsec-kernel/tasks/fetch_ubuntu_overlay.yml
@@ -3,7 +3,9 @@
   become: yes
   apt:
     name: git-core
-    state: present
+    state: latest
+    update_cache: true
+    cache_valid_time: 3600
 
 - name: clone ubuntu overlay git repository (slow!)
   git:

--- a/roles/build-grsec-kernel/tasks/gpg_keys.yml
+++ b/roles/build-grsec-kernel/tasks/gpg_keys.yml
@@ -25,4 +25,3 @@
   register: gpg_henriques_import
   changed_when: "'imported: 1' in gpg_henriques_import.stderr"
   when: grsecurity_build_include_ubuntu_overlay == true
-

--- a/roles/build-grsec-kernel/tasks/packages.yml
+++ b/roles/build-grsec-kernel/tasks/packages.yml
@@ -21,7 +21,7 @@
 - name: Install required packages for building kernel.
   apt:
     name: "{{ item }}"
-    state: present
+    state: latest
     update_cache: true
     cache_valid_time: 3600
   with_items: "{{ grsecurity_build_apt_packages }}"

--- a/roles/install-grsec-kernel/tasks/packages.yml
+++ b/roles/install-grsec-kernel/tasks/packages.yml
@@ -11,7 +11,9 @@
   become: yes
   apt:
     name: "{{ item }}"
-    state: present
+    state: latest
+    update_cache: true
+    cache_valid_time: 3600
   # Always install paxtest, but allow paxctl to be skipped, in case paxctld is used.
   with_flattened:
     - ['paxtest']


### PR DESCRIPTION
* Always install the latest version of a package. Especially for packages like
  ccache, ensuring the latest version is installed will ensure best performance.
* No need to update package index files more than once per hour.
  `cache_valid_time` is now set accordingly.