### PR TITLE
Use pipelining, controlpersist to speed up Ansible SSH

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,2 +1,4 @@
 [defaults]
 roles_path = roles
+ssh_args = -o ControlMaster=auto -o ControlPersist=30m
+pipelining=True


### PR DESCRIPTION
* "Enabling pipelining reduces the number of SSH operations required to execute
  a module on the remote server, by executing many ansible modules without
  actual file transfer."
* ControlMaster and ControlPersist are together used to multiplex SSH
  connections. ControlPersist defines for how long the master connection will be
  kept open after the last SSH session on that connection has exited. "In
  particular, users may wish to raise the ControlPersist time to encourage
  performance. A value of 30 minutes may be appropriate." It is 60s by default.