### PR TITLE
Ensure configure tasklisk skipped when no custom config is passed

### DIFF
--- a/roles/build-grsec-kernel/defaults/main.yml
+++ b/roles/build-grsec-kernel/defaults/main.yml
@@ -15,7 +15,7 @@ grsecurity_build_strategy: manual
 # Premade config file for use during compilation. Useful if you've previously
 # run `make menuconfig` and want to restore the custom settings.
 # Using `None` rather than an empty string to ensure Ansible skips by default.
-grsecurity_build_custom_config: None
+grsecurity_build_custom_config: ''
 
 # When building for installation on Ubuntu, one should include the
 # overlay to ensure that Ubuntu-specific options for AppArmor work.


### PR DESCRIPTION
Setting grsecurity_build_custom_config to an empty str instead of None matches
the conditional statments in the main.yml of the grsec-build role. This way, the
configure and compile taskslists get skipped, and the running the role with the
manual strategy works as intended, instead of ending in failure.