### PR TITLE
Supports building under libvirt provider

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -30,7 +30,11 @@ Vagrant.configure("2") do |config|
     build.vm.provider "libvirt" do |v|
       v.memory = 2048
       v.cpus = available_vcpus
-      v.cpu_mode = 'host-passthrough'
+      # If you are experiencing CPU-compatibility warnings (esp. regarding lack
+      # of svm) try uncommenting out the following line (see
+      # https://github.com/freedomofpress/ansible-role-grsecurity/pull/85#issuecomment-266611369
+      # for more).
+      # v.cpu_mode = 'host-passthrough'
     end
   end
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -30,6 +30,7 @@ Vagrant.configure("2") do |config|
     build.vm.provider "libvirt" do |v|
       v.memory = 2048
       v.cpus = available_vcpus
+      v.cpu_mode = 'host-passthrough'
     end
   end
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -27,6 +27,10 @@ Vagrant.configure("2") do |config|
       v.memory = 2048
       v.customize ["modifyvm", :id, "--cpus", available_vcpus]
     end
+    build.vm.provider "libvirt" do |v|
+      v.memory = 2048
+      v.cpus = available_vcpus
+    end
   end
 
   # Separate machine for testing installation of .deb packages.


### PR DESCRIPTION
The previous config assumes that VirtualBox is used as the Vagrant
backend, and accordingly bumped the specs (RAM and CPU count) only under
VirtualBox. Although the previous config still created the `grsec-build`
host under the vagrant-libvirt backend when explicitly specified, the
host was created with only 512MB of RAM, which is insufficient for
building a kernel.

The existing logic for dynamically determining the max CPU count on the
host machine is now applied to libvirt as well as virtualbox for the
backend provider. Also bumping RAM to 2048MB, same as under virtualbox.