### PR TITLE
Reports meaningful "changed" status for ccache config

### DIFF
--- a/roles/build-grsec-kernel/tasks/ccache.yml
+++ b/roles/build-grsec-kernel/tasks/ccache.yml
@@ -2,6 +2,7 @@
 # Separate task list for ccache-related tasks,
 # to make dynamic inclusion easier. If grsecurity_build_use_ccache
 # is set to `false`, then the package won't even be installed.
+
 - name: Install ccache.
   apt:
     name: ccache
@@ -10,11 +11,21 @@
     cache_valid_time: 3600
   become: yes
 
-  # Increasing the cache size from 1GB (default) to 5GB.
-  # Testing of several successive compiles showed 5GB
-  # to be a reasonable limit:
-  #   $ ccache -s | grep size
-  #   cache size                           4.5 Gbytes
-  #   max cache size                       5.0 Gbytes
+- name: Read current ccache cache size.
+  shell: >
+    ccache --show-stats
+    | grep -P '^max cache size'
+    | perl -lane 'print "$F[-2] $F[-1]"'
+  changed_when: false
+  register: ccache_cache_size_result
+
+# Increasing the cache size from 1GB (default) to 5GB.
+# Testing of several successive compiles showed 5GB
+# to be a reasonable limit:
+#   $ ccache -s | grep size
+#   cache size                           4.5 Gbytes
+#   max cache size                       5.0 Gbytes
 - name: Increase ccache cache size.
-  command: ccache -M 5G
+  command: ccache --max-size 5G
+  register: ccache_set_cache_result
+  changed_when: not ccache_set_cache_result.stdout.endswith(ccache_cache_size_result.stdout)

--- a/roles/build-grsec-kernel/tasks/main.yml
+++ b/roles/build-grsec-kernel/tasks/main.yml
@@ -36,6 +36,7 @@
 - include: verify.yml
 
 - include: ccache.yml
+  tags: ccache
   when: grsecurity_build_use_ccache == true
 
 - include: prepare_source_directory.yml


### PR DESCRIPTION
Admittedly a cosmetic change, but during repeated runs of the role, one gets irritated at the inaccurate `changed` status reported by the ccache task.

Implementation uses a quick read-only shell command to inspect the current cache size for ccache (defaults to 1GB), then compares that value to the output of the cache set command. This way, on subsequent runs of the role, the cache set task will report unchanged, which is true.