### PR TITLE
Fixes dynamic loading of kernel config templates for build role

### DIFF
--- a/roles/build-grsec-kernel/defaults/main.yml
+++ b/roles/build-grsec-kernel/defaults/main.yml
@@ -14,8 +14,7 @@ grsecurity_build_strategy: manual
 
 # Premade config file for use during compilation. Useful if you've previously
 # run `make menuconfig` and want to restore the custom settings.
-# Using `None` rather than an empty string to ensure Ansible skips by default.
-grsecurity_build_custom_config: None
+grsecurity_build_custom_config: ''
 
 # When building for installation on Ubuntu, one should include the
 # overlay to ensure that Ubuntu-specific options for AppArmor work.

--- a/roles/build-grsec-kernel/tasks/configure.yml
+++ b/roles/build-grsec-kernel/tasks/configure.yml
@@ -1,13 +1,11 @@
 ---
 - name: Copy baseline grsecurity config template.
   copy:
-    src: "{{ item }}"
+    # Prioritize custom config file, if specified. Fallback to prebuilt config
+    # that ships with the role. If a custom file is specified but does not exist,
+    # this task will fail.
+    src: "{{ grsecurity_build_custom_config if grsecurity_build_custom_config != '' else 'config-'+grsecurity_build_strategy }}"
     dest: "{{ grsecurity_build_linux_source_directory }}/.config"
-  # Prioritize custom config file, if specified. Fallback to prebuilt
-  # config that ships with the role.
-  with_first_found:
-    - "{{ grsecurity_build_custom_config }}"
-    - config-{{ grsecurity_build_strategy }}
 
 - name: Ensure any new options are updated with defaults.
   command: make olddefconfig


### PR DESCRIPTION
The kernel config logic is determined (rather messily) by two variables:

  * `grsecurity_build_strategy`
  * `grsecurity_build_custom_config`

If the latter is defined, it should take precedence. If neither is
defined, however, then the role should skip writing the kernel config
altogether, since the build strategy is "manual" by default, which
requires an interactive run of `make menuconfig` or similar to set
config values.

Related to #48, #68, #77. 