### PR TITLE
Updates SecureDrop metapackage logic

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -38,6 +38,27 @@ Vagrant.configure("2") do |config|
     end
   end
 
+  # Using a Trusty-based VM for building SecureDrop kernels using the `stable` patches.
+  # Trusty boxes can't build `stable2` or `test` patches; see #30 for details:
+  # https://github.com/freedomofpress/grsec/issues/30
+  config.vm.define 'grsec-build-securedrop', primary: true do |build_sd|
+    build_sd.vm.box = "bento/ubuntu-14.04"
+    build_sd.vm.hostname = "grsec-build-securedrop"
+    build_sd.vm.provision :ansible do |ansible|
+      # Target the SecureDrop-specific playbook.
+      ansible.playbook = 'examples/build-grsecurity-kernel-securedrop.yml'
+      ansible.verbose = 'vv'
+    end
+    build_sd.vm.provider "virtualbox" do |v|
+      v.memory = 2048
+      v.customize ["modifyvm", :id, "--cpus", available_vcpus]
+    end
+    build_sd.vm.provider "libvirt" do |v|
+      v.memory = 2048
+      v.cpus = available_vcpus
+    end
+  end
+
   # Separate machine for testing installation of .deb packages.
   # In case of problems, you don't want to pollute the build machine
   # with the test packages.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -45,7 +45,16 @@ Vagrant.configure("2") do |config|
     build_sd.vm.box = "bento/ubuntu-14.04"
     build_sd.vm.hostname = "grsec-build-securedrop"
     build_sd.vm.provision :ansible do |ansible|
-      # Target the SecureDrop-specific playbook.
+      # Target the SecureDrop-specific playbook. Unfortunately Ansible won't
+      # display the `vars_prompt` when run via vagrant, so you should actually
+      # invoke `ansible-playbook` directly, like so:
+      #
+      # ansible-playbook -i .vagrant/provisioners/ansible/inventory/vagrant_ansible_inventory \
+      # -u vagrant \
+      # --private-key .vagrant/machines/grsec-build/libvirt/private_key \
+      # examples/build-grsecurity-kernel-securedrop.yml
+      #
+      # Wish that weren't necessary, but it is.
       ansible.playbook = 'examples/build-grsecurity-kernel-securedrop.yml'
       ansible.verbose = 'vv'
     end

--- a/examples/build-grsecurity-kernel-securedrop.yml
+++ b/examples/build-grsecurity-kernel-securedrop.yml
@@ -1,6 +1,6 @@
 ---
 - name: Build Linux kernel for SecureDrop.
-  hosts: grsec-build
+  hosts: grsec-build-securedrop
   vars_prompt:
     - name: grsecurity_build_download_username
       prompt: "Username for grsecurity HTTP auth"

--- a/examples/build-grsecurity-kernel-securedrop.yml
+++ b/examples/build-grsecurity-kernel-securedrop.yml
@@ -23,4 +23,5 @@
       # because it depends on dynamic facts from the build role for determining
       # the appropriate kernel version, to set as dependencies.
     - role: build-grsec-metapackage
+      grsecurity_metapackage_name: securedrop-grsec
       tags: metapackage

--- a/examples/build-grsecurity-kernel-securedrop.yml
+++ b/examples/build-grsecurity-kernel-securedrop.yml
@@ -24,6 +24,5 @@
       # the appropriate kernel version, to set as dependencies.
     - role: build-grsec-metapackage
       grsecurity_metapackage_name: securedrop-grsec
-      grsecurity_metapackage_kernel_version: 3.14.48
-      grsecurity_metapackage_kernel_version_suffix: r1
+      grsecurity_metapackage_kernel_version: 3.14.79
       tags: metapackage

--- a/examples/build-grsecurity-kernel-securedrop.yml
+++ b/examples/build-grsecurity-kernel-securedrop.yml
@@ -24,4 +24,6 @@
       # the appropriate kernel version, to set as dependencies.
     - role: build-grsec-metapackage
       grsecurity_metapackage_name: securedrop-grsec
+      grsecurity_metapackage_kernel_version: 3.14.48
+      grsecurity_metapackage_kernel_version_suffix: r1
       tags: metapackage

--- a/examples/build-grsecurity-kernel-securedrop.yml
+++ b/examples/build-grsecurity-kernel-securedrop.yml
@@ -1,0 +1,26 @@
+---
+- name: Build Linux kernel for SecureDrop.
+  hosts: grsec-build
+  vars_prompt:
+    - name: grsecurity_build_download_username
+      prompt: "Username for grsecurity HTTP auth"
+      # Warning: setting `private: no` for username entry
+      # should cause the entered text to echo back, but
+      # won't work when provisioning with Vagrant. See here:
+      # https://github.com/mitchellh/vagrant/issues/2924
+    - name: grsecurity_build_download_password
+      prompt: "Password for grsecurity HTTP auth"
+  roles:
+    - role: build-grsec-kernel
+      # Use 3.x stable kernel series for now, since we're running under Trusty.
+      # Future versions of SecureDrop may depend on the 4.x series, in which case
+      # the `stable2` patch type should be used.
+      grsecurity_build_patch_type: stable
+      grsecurity_build_include_ubuntu_overlay: true
+      tags: kernel
+
+      # Running the metapackage role *after* the build role is important,
+      # because it depends on dynamic facts from the build role for determining
+      # the appropriate kernel version, to set as dependencies.
+    - role: build-grsec-metapackage
+      tags: metapackage

--- a/examples/build-grsecurity-kernel-stable.yml
+++ b/examples/build-grsecurity-kernel-stable.yml
@@ -11,9 +11,6 @@
     - name: grsecurity_build_download_password
       prompt: "Password for grsecurity HTTP auth"
   roles:
-    - role: build-grsec-metapackage
-      tags: metapackage
-
     - role: build-grsec-kernel
       grsecurity_build_patch_type: stable2
       tags: kernel

--- a/roles/build-grsec-metapackage/defaults/main.yml
+++ b/roles/build-grsec-metapackage/defaults/main.yml
@@ -1,9 +1,8 @@
 ---
-grsec_package_name: securedrop-grsec
-grsec_build_parent_directory: /tmp/build
-grsec_kernel_version: "4.4.32"
-securedrop_version: "0.3.10"
-securedrop_architecture: amd64
+grsecurity_metapackage_name: securedrop-grsec
+grsecurity_metapackage_parent_directory: /tmp/build
+grsecurity_metapackage_kernel_version: "3.14.79"
+grsecurity_metapackage_architecture: amd64
 
-grsec_package_name_verbose: "{{ grsec_package_name }}-{{ grsec_kernel_version }}-{{ securedrop_architecture }}"
-grsec_build_directory: "{{ grsec_build_parent_directory }}/{{ grsec_package_name_verbose }}"
+grsecurity_metapackage_name_verbose: "{{ grsecurity_metapackage_name }}-{{ grsecurity_metapackage_kernel_version }}-{{ grsecurity_metapackage_architecture }}"
+grsecurity_metapackage_build_directory: "{{ grsecurity_metapackage_parent_directory }}/{{ grsecurity_metapackage_name_verbose }}"

--- a/roles/build-grsec-metapackage/defaults/main.yml
+++ b/roles/build-grsec-metapackage/defaults/main.yml
@@ -12,6 +12,11 @@ grsecurity_metapackage_parent_directory: /tmp/build
 # play, then the var won't be defined, so let's set it to a string in that case.
 grsecurity_metapackage_kernel_version: "{{ linux_kernel_version|default('3.14.79') }}"
 
+# Optional appended version for chaining versions, e.g. "3.14.79+0.0.1".
+# Can be useful for shipping new versions of the metapackage without bumping
+# the underlying dependencies.
+grsecurity_metapackage_kernel_version_suffix: ''
+
 # Architecture restriction for the control file for metapackage. Should match
 # what was chosen in the build role.
 grsecurity_metapackage_architecture: amd64

--- a/roles/build-grsec-metapackage/defaults/main.yml
+++ b/roles/build-grsec-metapackage/defaults/main.yml
@@ -1,8 +1,22 @@
 ---
+# Name of the metapackage created by this role.
 grsecurity_metapackage_name: securedrop-grsec
+
+# Path to working directory for preparing build on target host.
 grsecurity_metapackage_parent_directory: /tmp/build
-grsecurity_metapackage_kernel_version: "3.14.79"
+
+# Version of the Linux kernel that was patched, reused as 'Version' in the
+# control file for this metapackage. Provides meaningful semver for upgrades.
+# The `build-grsec-kernel` role will dynamically define `linux_kernel_version`
+# based on patch type selected. If the metapackage role is called in a different
+# play, then the var won't be defined, so let's set it to a string in that case.
+grsecurity_metapackage_kernel_version: "{{ linux_kernel_version|default('3.14.79') }}"
+
+# Architecture restriction for the control file for metapackage. Should match
+# what was chosen in the build role.
 grsecurity_metapackage_architecture: amd64
 
+# Reusable vars for filepaths and filenames, so the built package can be fetched back
+# to the Ansible controller.
 grsecurity_metapackage_name_verbose: "{{ grsecurity_metapackage_name }}-{{ grsecurity_metapackage_kernel_version }}-{{ grsecurity_metapackage_architecture }}"
 grsecurity_metapackage_build_directory: "{{ grsecurity_metapackage_parent_directory }}/{{ grsecurity_metapackage_name_verbose }}"

--- a/roles/build-grsec-metapackage/defaults/main.yml
+++ b/roles/build-grsec-metapackage/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # Name of the metapackage created by this role.
-grsecurity_metapackage_name: securedrop-grsec
+grsecurity_metapackage_name: linux-grsec-metapackage
 
 # Path to working directory for preparing build on target host.
 grsecurity_metapackage_parent_directory: /tmp/build

--- a/roles/build-grsec-metapackage/files/paxctl-grub
+++ b/roles/build-grsec-metapackage/files/paxctl-grub
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -e
+
+# Set PaX flags on GRUB binaries. Required when running under a grsec kernel,
+# i.e. during kernel upgrades. If the GRUB binaries do not have the proper flags,
+# the kernel image will fail to install.
+#
+# This script must run prior to the `zz-update-grub` kernel postinst hook,
+# 
+paxctl -Cpm /usr/sbin/grub-probe
+paxctl -Cpm /usr/sbin/grub-mkdevicemap

--- a/roles/build-grsec-metapackage/files/paxctl-grub
+++ b/roles/build-grsec-metapackage/files/paxctl-grub
@@ -14,3 +14,4 @@ set -e
 # not maintained by this script will be removed.
 paxctl -zCE /usr/sbin/grub-probe
 paxctl -zCE /usr/sbin/grub-mkdevicemap
+paxctl -zCE /usr/bin/grub-script-check

--- a/roles/build-grsec-metapackage/files/paxctl-grub
+++ b/roles/build-grsec-metapackage/files/paxctl-grub
@@ -6,6 +6,11 @@ set -e
 # the kernel image will fail to install.
 #
 # This script must run prior to the `zz-update-grub` kernel postinst hook,
-# 
-paxctl -Cpm /usr/sbin/grub-probe
-paxctl -Cpm /usr/sbin/grub-mkdevicemap
+# which will happen automatically due to sorting of the postinst scripts.
+#
+# Enabling EMUTRAMP on grub binaries, which requires `CONFIG_PAX_EMUTRAMP=y`
+# to be set in the kernel config. Using `-z` to clear out any other flags,
+# so the binaries will get only the intended settings, and all others
+# not maintained by this script will be removed.
+paxctl -zCE /usr/sbin/grub-probe
+paxctl -zCE /usr/sbin/grub-mkdevicemap

--- a/roles/build-grsec-metapackage/tasks/main.yml
+++ b/roles/build-grsec-metapackage/tasks/main.yml
@@ -2,29 +2,29 @@
 - name: Create parent build directory.
   file:
     state: directory
-    path: "{{ grsec_build_parent_directory }}"
+    path: "{{ grsecurity_metapackage_parent_directory }}"
 
 - name: Clean build subdirectory.
   file:
     state: absent
-    path: "{{ grsec_build_directory }}"
+    path: "{{ grsecurity_metapackage_build_directory }}"
 
 - name: Create build subdirectory.
   file:
     state: directory
-    path: "{{ grsec_build_directory }}/DEBIAN"
+    path: "{{ grsecurity_metapackage_build_directory }}/DEBIAN"
 
 - name: Copy DEBIAN control file.
   template:
     src: debian-control-file
-    dest: "{{ grsec_build_directory }}/DEBIAN/control"
+    dest: "{{ grsecurity_metapackage_build_directory }}/DEBIAN/control"
 
 - name: Build the Debian package.
-  command: dpkg-deb --build {{ grsec_build_directory }}
+  command: dpkg-deb --build {{ grsecurity_metapackage_build_directory }}
 
 - name: Fetch metapackage back to localhost.
   fetch:
-    src: "{{ grsec_build_parent_directory }}/{{ grsec_package_name_verbose }}.deb"
+    src: "{{ grsecurity_metapackage_parent_directory }}/{{ grsecurity_metapackage_name_verbose }}.deb"
     dest: built-packages/
     flat: yes
 

--- a/roles/build-grsec-metapackage/tasks/main.yml
+++ b/roles/build-grsec-metapackage/tasks/main.yml
@@ -5,6 +5,7 @@
     path: "{{ grsecurity_metapackage_parent_directory }}"
 
 - name: Clean build subdirectory.
+  become: yes
   file:
     state: absent
     path: "{{ grsecurity_metapackage_build_directory }}"
@@ -19,6 +20,24 @@
     src: debian-control-file
     dest: "{{ grsecurity_metapackage_build_directory }}/DEBIAN/control"
 
+- name: Create files directory for kernel postinst hook.
+  become: yes
+  file:
+    state: directory
+    mode: "0755"
+    owner: root
+    group: root
+    dest: "{{ grsecurity_metapackage_build_directory }}/etc/kernel/postinst.d"
+
+- name: Copy kernel postinst hook for PaX flag maintenance.
+  become: yes
+  copy:
+    src: paxctl-grub
+    mode: "0755"
+    owner: root
+    group: root
+    dest: "{{ grsecurity_metapackage_build_directory }}/etc/kernel/postinst.d/paxctl-grub"
+
 - name: Build the Debian package.
   command: dpkg-deb --build {{ grsecurity_metapackage_build_directory }}
 
@@ -27,4 +46,3 @@
     src: "{{ grsecurity_metapackage_parent_directory }}/{{ grsecurity_metapackage_name_verbose }}.deb"
     dest: built-packages/
     flat: yes
-

--- a/roles/build-grsec-metapackage/templates/debian-control-file
+++ b/roles/build-grsec-metapackage/templates/debian-control-file
@@ -1,9 +1,9 @@
-Package: {{ grsec_package_name }}
-Source: {{ grsec_package_name }}
-Version: {{ grsec_kernel_version }}
-Architecture: {{ securedrop_architecture }}
+Package: {{ grsecurity_metapackage_name }}
+Source: {{ grsecurity_metapackage_name }}
+Version: {{ grsecurity_metapackage_kernel_version }}
+Architecture: {{ grsecurity_metapackage_architecture }}
 Maintainer: SecureDrop Team <securedrop@freedom.press>
-Depends: linux-image-{{ grsec_kernel_version }}-grsec
+Depends: linux-image-{{ grsecurity_metapackage_kernel_version }}-grsec
 Section: admin
 Priority: optional
 Homepage: https://securedrop.org

--- a/roles/build-grsec-metapackage/templates/debian-control-file
+++ b/roles/build-grsec-metapackage/templates/debian-control-file
@@ -1,6 +1,6 @@
 Package: {{ grsecurity_metapackage_name }}
 Source: {{ grsecurity_metapackage_name }}
-Version: {{ grsecurity_metapackage_kernel_version }}
+Version: {{ grsecurity_metapackage_kernel_version }}{{ '+'+grsecurity_metapackage_kernel_version_suffix if grsecurity_metapackage_kernel_version_suffix else '' }}
 Architecture: {{ grsecurity_metapackage_architecture }}
 Maintainer: SecureDrop Team <securedrop@freedom.press>
 Depends: linux-image-{{ grsecurity_metapackage_kernel_version }}-grsec


### PR DESCRIPTION
Overhaul of the `build-grsec-metapackage` role. Makes it more generally applicable to reuse, and importantly adds a postinst kernel hook to ensure state of PaX flags on grub binaries (closes #90). These changes recently shipped in the context of SecureDrop, and the config presented here was used for the build.

Also adds a dedicated `grsec-build-securedrop` VM, tracking Trusty and using a dedicated playbook specifically for the SD build process (closes #89).