### PR TITLE
Fixes reboot logic

### DIFF
--- a/roles/install-grsec-kernel/defaults/main.yml
+++ b/roles/install-grsec-kernel/defaults/main.yml
@@ -33,3 +33,7 @@ grsecurity_install_force_install: false
 # we'll override this setting if the role is running against localhost, to prevent
 # reboots of the Ansible controller.
 grsecurity_install_reboot: true
+
+# If rebooting, wait for additional time after the SSH port reports being open.
+# Some hosts respond early to port listening before logins are accepted.
+grsecurity_install_extra_wait_seconds: 30

--- a/roles/install-grsec-kernel/defaults/main.yml
+++ b/roles/install-grsec-kernel/defaults/main.yml
@@ -29,6 +29,7 @@ grsecurity_install_download_dir: /usr/local/src
 # for example while developing a new kernel config, set this to true.
 grsecurity_install_force_install: false
 
-# If the target host is remote, assume that rebooting is desired, but don't
-# reboot if we're installing on localhost.
-grsecurity_install_reboot: "{{ false if ansible_connection == 'local' else true }}"
+# If the target host is remote, assume that rebooting is desired. At the task level,
+# we'll override this setting if the role is running against localhost, to prevent
+# reboots of the Ansible controller.
+grsecurity_install_reboot: true

--- a/roles/install-grsec-kernel/tasks/main.yml
+++ b/roles/install-grsec-kernel/tasks/main.yml
@@ -9,13 +9,3 @@
 - include: grub_config.yml
 
 - include: validate_install.yml
-  when: grsecurity_install_desired_kernel_version != ansible_kernel and
-        grsecurity_install_reboot == true
-
-- name: Display message about required reboot.
-  debug:
-    msg: >-
-      Installed grsecurity-patched kernel version '{{ grsecurity_install_desired_kernel_version }}'.
-      You must reboot the host to load the new kernel.
-  when: grsecurity_install_desired_kernel_version != ansible_kernel and
-        grsecurity_install_reboot == false

--- a/roles/install-grsec-kernel/tasks/set_host_facts.yml
+++ b/roles/install-grsec-kernel/tasks/set_host_facts.yml
@@ -2,6 +2,13 @@
 - name: Get GRUB menu options as host facts.
   action: grub_menu_options
 
+  # Override the role default to disable reboots if running against
+  # localhost. Under no circumstances should this role reboot localhost.
+- name: Check if running against Ansible controller, to prevent reboots.
+  set_fact:
+    grsecurity_install_reboot: false
+  when: ansible_connection == 'local'
+
   # Role requires that at least one of `grsecurity_install_deb_package` or
   # `grsecurity_install_deb_packages` be defined.
 - name: Check filename for deb package.

--- a/roles/install-grsec-kernel/tasks/validate_install.yml
+++ b/roles/install-grsec-kernel/tasks/validate_install.yml
@@ -36,3 +36,13 @@
       Grsecurity kernel is not running. Expected to find
       {{ grsecurity_install_desired_kernel_version }}. Instead, found
       kernel {{ ansible_kernel }}.
+  when: grsecurity_install_desired_kernel_version != ansible_kernel and
+        grsecurity_install_reboot == true
+
+- name: Display message about required reboot.
+  debug:
+    msg: >-
+      Installed grsecurity-patched kernel version '{{ grsecurity_install_desired_kernel_version }}'.
+      You must reboot the host to load the new kernel.
+  when: grsecurity_install_desired_kernel_version != ansible_kernel and
+        grsecurity_install_reboot == false

--- a/roles/install-grsec-kernel/tasks/validate_install.yml
+++ b/roles/install-grsec-kernel/tasks/validate_install.yml
@@ -17,12 +17,9 @@
     state=started
   become: false
 
-  # Adding extra wait time to prevent timeouts
-  # during debugging. Likely not necessary, but test
-  # before removing.
 - name: Wait extra time for server to come back up.
   pause:
-    seconds: 30
+    seconds: "{{ grsecurity_install_extra_wait_seconds }}"
 
   # Running the setup module will refresh the `ansible_kernel` host fact
   # with the current value. The `grsecurity_install_desired_kernel_version` host fact

--- a/roles/install-grsec-kernel/tasks/validate_install.yml
+++ b/roles/install-grsec-kernel/tasks/validate_install.yml
@@ -11,8 +11,8 @@
 
 - name: Wait for server to come back.
   local_action: wait_for
-    host={{ ansible_ssh_host }}
-    port={{ ansible_ssh_port | default('22')}}
+    host={{ ansible_ssh_host|default(ansible_host|default(inventory_hostname)) }}
+    port={{ ansible_ssh_port|default(ansible_port|default('22')) }}
     delay=30
     state=started
   become: false


### PR DESCRIPTION
Updates the conditional logic to preserve support for changes brought in via #59, but also to make sure that remote hosts are properly waited for if rebooted. Hard-codes an exemption to the logic such that localhost will never be rebooted.

Closes #94.