### PR TITLE
Removes support for grsecurity "test" patches

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,27 @@ grsecurity_build_fetch_packages: true
 # The "test" patches do not require authentication or a subscription.
 grsecurity_build_download_username: ''
 grsecurity_build_download_password: ''
+
+# List of GPG keys required for building grsecurity-patched kernel.
+grsecurity_build_gpg_keys:
+  - name: Greg Kroah-Hartman GPG key (Linux stable release signing key)
+    fingerprint: 647F28654894E3BD457199BE38DBBDC86092693E
+  - name: kernel.org checksum autosigner GPG key
+    fingerprint: B8868C80BA62A1FFFAF5FDA9632D3A06589DA6B1
+  - name: Bradley Spengler GPG key (grsecurity maintainer key)
+    fingerprint: DE9452CE46F42094907F108B44D1C0F82525FE49
+
+# List of GPG keys required for building grsecurity-patched kernel with the ubuntu-overlay.
+# Only imported if the ubuntu-overlay is included via the `grsecurity_build_include_ubuntu_overlay` var.
+grsecurity_build_gpg_keys_ubuntu:
+  - name: Brad Figg GPG key (Canonical/Ubuntu Kernel Team)
+    fingerprint: 11D6ADA3D9E83D93ACBD837F0C7B589B105BE7F7
+  - name: Luis Henriques GPG key (Canonical/LKM)
+    fingerprint: D4E1E31744709144B0F8101ADB74AEB8FDCE24FC
+  - name: Stefan Bader GPG key (Canonical/Ubuntu Kernel Team)
+    fingerprint: DB5D7CCAF3994E3395DA4D3EE8675DEECBEECEA3
+  - name: Thadeu Lima de Souza Cascardo (Canonical)
+    fingerprint: 279357DB6127376E6D1DF1BCAAD56799FBFD0D3E
 ```
 
 ### install-grsec-kernel

--- a/README.md
+++ b/README.md
@@ -83,10 +83,9 @@ to discuss how such a change might affect your workflow.
 
 ### build-grsec-kernel
 ```yaml
-# Can be "stable" or "test". Note that stable patches
-# requires authentication to download. See the grsecurity
-# blog for more information: https://grsecurity.net/announce.php
-grsecurity_build_patch_type: test
+# Can be "stable" or "stable2". Defaults to "stable2" because "stable"
+# applies to the 3.14.79 kernel source, which has been EOL'd.
+grsecurity_build_patch_type: stable2
 
 # The default "manual" strategy will prep a machine for compilation,
 # but stop short of configuring and compiling. You can instead choose

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,7 +3,40 @@
 
 Vagrant.configure("2") do |config|
 
-  config.vm.define 'grsec-build', primary: true do |build|
+  # Using a Trusty-based VM for building SecureDrop kernels using the `stable` patches.
+  # Trusty boxes can't build `stable2` or `test` patches; see #30 for details:
+  # https://github.com/freedomofpress/grsec/issues/30
+  config.vm.define 'grsec-build-securedrop', primary: true do |build_sd|
+    build_sd.vm.box = "bento/ubuntu-14.04"
+    build_sd.vm.hostname = "grsec-build-securedrop"
+    build_sd.vm.provision :ansible do |ansible|
+      # Target the SecureDrop-specific playbook. Unfortunately Ansible won't
+      # display the `vars_prompt` when run via vagrant, so you should actually
+      # invoke `ansible-playbook` directly, like so:
+      #
+      # ansible-playbook -i .vagrant/provisioners/ansible/inventory/vagrant_ansible_inventory \
+      # -u vagrant \
+      # --private-key .vagrant/machines/grsec-build/libvirt/private_key \
+      # examples/build-grsecurity-kernel-securedrop.yml
+      #
+      # Wish that weren't necessary, but it is.
+      ansible.playbook = 'examples/build-grsecurity-kernel-securedrop.yml'
+      ansible.verbose = 'vv'
+    end
+    build_sd.vm.provider "virtualbox" do |v|
+      v.memory = 2048
+      v.customize ["modifyvm", :id, "--cpus", available_vcpus]
+    end
+    build_sd.vm.provider "libvirt" do |v|
+      v.memory = 2048
+      v.cpus = available_vcpus
+    end
+  end
+
+  # Deprecated machine intended to test grsecurity patches generally,
+  # not specifically in the SecureDrop context. Vivid is EOL, so changes
+  # are required to get this machine running again.
+  config.vm.define 'grsec-build', autostart: false do |build|
     # Using Ubuntu 15.04 rather than 14.04 LTS due to a bug in kernel-package.
     # See #30 for details: https://github.com/freedomofpress/grsec/issues/30
     build.vm.box = "ubuntu/vivid64"
@@ -35,36 +68,6 @@ Vagrant.configure("2") do |config|
       # https://github.com/freedomofpress/ansible-role-grsecurity/pull/85#issuecomment-266611369
       # for more).
       # v.cpu_mode = 'host-passthrough'
-    end
-  end
-
-  # Using a Trusty-based VM for building SecureDrop kernels using the `stable` patches.
-  # Trusty boxes can't build `stable2` or `test` patches; see #30 for details:
-  # https://github.com/freedomofpress/grsec/issues/30
-  config.vm.define 'grsec-build-securedrop', primary: true do |build_sd|
-    build_sd.vm.box = "bento/ubuntu-14.04"
-    build_sd.vm.hostname = "grsec-build-securedrop"
-    build_sd.vm.provision :ansible do |ansible|
-      # Target the SecureDrop-specific playbook. Unfortunately Ansible won't
-      # display the `vars_prompt` when run via vagrant, so you should actually
-      # invoke `ansible-playbook` directly, like so:
-      #
-      # ansible-playbook -i .vagrant/provisioners/ansible/inventory/vagrant_ansible_inventory \
-      # -u vagrant \
-      # --private-key .vagrant/machines/grsec-build/libvirt/private_key \
-      # examples/build-grsecurity-kernel-securedrop.yml
-      #
-      # Wish that weren't necessary, but it is.
-      ansible.playbook = 'examples/build-grsecurity-kernel-securedrop.yml'
-      ansible.verbose = 'vv'
-    end
-    build_sd.vm.provider "virtualbox" do |v|
-      v.memory = 2048
-      v.customize ["modifyvm", :id, "--cpus", available_vcpus]
-    end
-    build_sd.vm.provider "libvirt" do |v|
-      v.memory = 2048
-      v.cpus = available_vcpus
     end
   end
 

--- a/roles/build-grsec-kernel/defaults/main.yml
+++ b/roles/build-grsec-kernel/defaults/main.yml
@@ -1,8 +1,7 @@
 ---
-# Can be "stable" or "test". Note that stable patches
-# requires authentication to download. See the grsecurity
-# blog for more information: https://grsecurity.net/announce.php
-grsecurity_build_patch_type: test
+# Can be "stable" or "stable2". Defaults to "stable2" because "stable"
+# applies to the 3.14.79 kernel source, which has been EOL'd.
+grsecurity_build_patch_type: stable2
 
 # The default "manual" strategy will prep a machine for compilation,
 # but stop short of configuring and compiling. You can instead choose

--- a/roles/build-grsec-kernel/defaults/main.yml
+++ b/roles/build-grsec-kernel/defaults/main.yml
@@ -89,3 +89,5 @@ grsecurity_build_gpg_keys_ubuntu:
     fingerprint: D4E1E31744709144B0F8101ADB74AEB8FDCE24FC
   - name: Stefan Bader GPG key (Canonical/Ubuntu Kernel Team)
     fingerprint: DB5D7CCAF3994E3395DA4D3EE8675DEECBEECEA3
+  - name: Thadeu Lima de Souza Cascardo (Canonical)
+    fingerprint: 279357DB6127376E6D1DF1BCAAD56799FBFD0D3E

--- a/roles/build-grsec-kernel/library/grsecurity_urls.py
+++ b/roles/build-grsec-kernel/library/grsecurity_urls.py
@@ -16,15 +16,14 @@ options:
       - Branch of grsecurity kernel patches.
         See https://grsecurity.net/download.php for more info.
 
-    default: "test"
-    choices: [ "test", "stable", "stable2" ]
+    default: "stable2"
+    choices: [ "stable", "stable2" ]
     required: no
 notes:
   - The Linux kernel version is dependent on the grsecurity patch type.
 '''
 EXAMPLES = '''
 - action: grsecurity_urls
-- action: grsecurity_urls patch_type=test
 - action: grsecurity_urls patch_type=stable
 - action: grsecurity_urls patch_type=stable2
 '''
@@ -44,9 +43,7 @@ GRSECURITY_BASE_URL = 'https://grsecurity.net/'
 GRSECURITY_LATEST_STABLE_PATCH_URL = 'https://grsecurity.net/latest_stable_patch'
 # The "stable2" patches use kernel version 4.x
 GRSECURITY_LATEST_STABLE2_PATCH_URL = 'https://grsecurity.net/latest_stable2_patch'
-GRSECURITY_LATEST_TEST_PATCH_URL = 'https://grsecurity.net/latest_test_patch'
 GRSECURITY_STABLE_URL_PREFIX = 'https://grsecurity.net/download-restrict/download-redirect.php?file='
-GRSECURITY_TEST_URL_PREFIX = 'https://grsecurity.net/test/'
 GRSECURITY_FILENAME_REGEX = re.compile(r'''
                                         grsecurity-
                                         (?P<grsecurity_version>\d+\.\d+)-
@@ -130,10 +127,8 @@ class GrsecurityURLs():
         url = ''
         if self.patch_type == "stable":
             url = GRSECURITY_LATEST_STABLE_PATCH_URL
-        elif self.patch_type == "stable2":
-            url = GRSECURITY_LATEST_STABLE2_PATCH_URL
         else:
-            url = GRSECURITY_LATEST_TEST_PATCH_URL
+            url = GRSECURITY_LATEST_STABLE2_PATCH_URL
         return url
 
 
@@ -147,12 +142,8 @@ class GrsecurityURLs():
         config = dict()
         config['grsecurity_patch_filename'] = patch_name
 
-        if self.patch_type == "stable":
-            config['grsecurity_patch_url'] = GRSECURITY_STABLE_URL_PREFIX+patch_name
-        elif self.patch_type == "stable2":
-            config['grsecurity_patch_url'] = GRSECURITY_STABLE_URL_PREFIX+patch_name
-        else:
-            config['grsecurity_patch_url'] = GRSECURITY_TEST_URL_PREFIX+patch_name
+        # Filename changes between 'stable' and 'stable2', but base URL does not.
+        config['grsecurity_patch_url'] = GRSECURITY_STABLE_URL_PREFIX+patch_name
 
         config['grsecurity_signature_filename'] = config['grsecurity_patch_filename'] + '.sig'
         config['grsecurity_signature_url'] = config['grsecurity_patch_url'] + '.sig'
@@ -164,7 +155,7 @@ class GrsecurityURLs():
 def main():
     module = AnsibleModule(
         argument_spec=dict(
-            patch_type=dict(default="test", choices=["test", "stable", "stable2"]),
+            patch_type=dict(default="stable2", choices=["stable", "stable2"]),
         ),
         supports_check_mode=False
     )

--- a/roles/build-grsec-kernel/tasks/gpg_keys.yml
+++ b/roles/build-grsec-kernel/tasks/gpg_keys.yml
@@ -2,12 +2,12 @@
 - name: Import GPG keys for building Linux kernel.
   command: gpg --keyserver {{ grsecurity_build_gpg_keyserver }} --recv-keys "{{ item.fingerprint }}"
   register: gpg_import_linux_pubkeys_result
-  changed_when: "'imported: 1' in gpg_import_linux_pubkeys_result.item.stderr"
+  changed_when: "'imported: 1' in gpg_import_linux_pubkeys_result.stderr"
   with_items: "{{ grsecurity_build_gpg_keys }}"
 
 - name: Import GPG keys for building Linux kernel.
   command: gpg --keyserver {{ grsecurity_build_gpg_keyserver }} --recv-keys "{{ item.fingerprint }}"
   register: gpg_import_ubuntu_pubkeys_result
-  changed_when: "'imported: 1' in gpg_import_ubuntu_pubkeys_result.item.stderr"
+  changed_when: "'imported: 1' in gpg_import_ubuntu_pubkeys_result.stderr"
   with_items: "{{ grsecurity_build_gpg_keys_ubuntu }}"
   when: grsecurity_build_include_ubuntu_overlay == true


### PR DESCRIPTION
Closes #103. Removes support for the "test" patch type, since those patches are no longer distributed by grsecurity. Switches to the "stable2" patch type by default now, although support for the "stable" patch type remains (#80). 

Includes some cleanup for the GPG fetching that should have made it into #100 (added during review), but didn't. 

Also includes a rather out-of-band disabling of one of the Vivid-based VMs, simply because the Vivid base box image is no longer hosted, so it won't run by default. Preserve the config block, merely set autostart to disabled. Will circle back to revive that config soon, so it can be used for testing again. 