### PR TITLE
Supports redirects in grsecurity URL lookups

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,8 +140,8 @@ grsecurity_build_fetch_packages: true
 
 # Credentials for downloading the grsecurity "stable" pages. Requires subscription.
 # The "test" patches do not require authentication or a subscription.
-grsecurity_build_download_username: ''
-grsecurity_build_download_password: ''
+grsecurity_build_download_username: "{{ lookup('env', 'GRSECURITY_USERNAME')|default('') }}"
+grsecurity_build_download_password: "{{ lookup('env', 'GRSECURITY_PASSWORD')|default('') }}"
 
 # List of GPG keys required for building grsecurity-patched kernel.
 grsecurity_build_gpg_keys:

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,16 +10,6 @@ Vagrant.configure("2") do |config|
     build_sd.vm.box = "bento/ubuntu-14.04"
     build_sd.vm.hostname = "grsec-build-securedrop"
     build_sd.vm.provision :ansible do |ansible|
-      # Target the SecureDrop-specific playbook. Unfortunately Ansible won't
-      # display the `vars_prompt` when run via vagrant, so you should actually
-      # invoke `ansible-playbook` directly, like so:
-      #
-      # ansible-playbook -i .vagrant/provisioners/ansible/inventory/vagrant_ansible_inventory \
-      # -u vagrant \
-      # --private-key .vagrant/machines/grsec-build/libvirt/private_key \
-      # examples/build-grsecurity-kernel-securedrop.yml
-      #
-      # Wish that weren't necessary, but it is.
       ansible.playbook = 'examples/build-grsecurity-kernel-securedrop.yml'
       ansible.verbose = 'vv'
     end

--- a/examples/build-grsecurity-kernel-securedrop.yml
+++ b/examples/build-grsecurity-kernel-securedrop.yml
@@ -1,15 +1,19 @@
 ---
 - name: Build Linux kernel for SecureDrop.
   hosts: grsec-build-securedrop
-  vars_prompt:
-    - name: grsecurity_build_download_username
-      prompt: "Username for grsecurity HTTP auth"
-      # Warning: setting `private: no` for username entry
-      # should cause the entered text to echo back, but
-      # won't work when provisioning with Vagrant. See here:
-      # https://github.com/mitchellh/vagrant/issues/2924
-    - name: grsecurity_build_download_password
-      prompt: "Password for grsecurity HTTP auth"
+  pre_tasks:
+    # You can set these values via env vars:
+    #
+    #   * GRSECURITY_USERNAME
+    #   * GRSECURITY_PASSWORD
+    #
+    # The role will then automatically pick them up and these assert
+    # statements will pass.
+    - name: Check for grsecurity login credentials.
+      assert:
+        that:
+          - grsecurity_build_download_username != ''
+          - grsecurity_build_download_password != ''
   roles:
     - role: build-grsec-kernel
       # Use 3.x stable kernel series for now, since we're running under Trusty.

--- a/roles/build-grsec-kernel/defaults/main.yml
+++ b/roles/build-grsec-kernel/defaults/main.yml
@@ -67,8 +67,8 @@ grsecurity_build_fetch_packages_dest: "./"
 
 # Credentials for downloading the grsecurity "stable" pages. Requires subscription.
 # The "test" patches do not require authentication or a subscription.
-grsecurity_build_download_username: ''
-grsecurity_build_download_password: ''
+grsecurity_build_download_username: "{{ lookup('env', 'GRSECURITY_USERNAME')|default('') }}"
+grsecurity_build_download_password: "{{ lookup('env', 'GRSECURITY_PASSWORD')|default('') }}"
 
 # List of GPG keys required for building grsecurity-patched kernel.
 grsecurity_build_gpg_keys:

--- a/roles/build-grsec-kernel/tasks/fetch_grsecurity_files.yml
+++ b/roles/build-grsec-kernel/tasks/fetch_grsecurity_files.yml
@@ -1,14 +1,19 @@
 ---
+# Not using get_url because it doesn't follow redirects.
 - name: Fetch grsecurity patch.
-  get_url:
-      url: "{{ grsecurity_patch_url  }}"
-      dest: "{{ grsecurity_build_download_directory }}/{{ grsecurity_patch_filename }}"
-      url_username: "{{ grsecurity_build_download_username }}"
-      url_password: "{{ grsecurity_build_download_password }}"
+  command: >-
+    curl
+    --user "{{ grsecurity_build_download_username }}:{{ grsecurity_build_download_password }}"
+    -L "{{ grsecurity_patch_url  }}"
+    -o "{{ grsecurity_build_download_directory }}/{{ grsecurity_patch_filename }}"
+  args:
+    creates: "{{ grsecurity_build_download_directory }}/{{ grsecurity_patch_filename }}"
 
 - name: Fetch grsecurity signature.
-  get_url:
-      url: "{{ grsecurity_signature_url  }}"
-      dest: "{{ grsecurity_build_download_directory }}/{{ grsecurity_signature_filename }}"
-      url_username: "{{ grsecurity_build_download_username }}"
-      url_password: "{{ grsecurity_build_download_password }}"
+  command: >-
+    curl
+    --user "{{ grsecurity_build_download_username }}:{{ grsecurity_build_download_password }}"
+    -L "{{ grsecurity_signature_url  }}"
+    -o "{{ grsecurity_build_download_directory }}/{{ grsecurity_signature_filename }}"
+  args:
+    creates: "{{ grsecurity_build_download_directory }}/{{ grsecurity_signature_filename }}"


### PR DESCRIPTION
Recent changes to the backend API for grsecurity patch sets (at least for FPF) have made it necessary to support 3xx codes during lookups, so that a redirect can provide a custom URL path for the patch and signature file downloads.

Was not able to force Ansible's `get_url` module to honor redirects, surprisingly, so fell back to using `curl` via the `command` module. Hardly ideal, but sufficient for our use case. Preserved idempotence by checking for file existence and skipping the fetch if an exact fliename match is found on disk.

Closes #104.