### PR TITLE
Uses MIT PGP keyserver by default

### DIFF
--- a/roles/build-grsec-kernel/defaults/main.yml
+++ b/roles/build-grsec-kernel/defaults/main.yml
@@ -27,7 +27,8 @@ grsecurity_build_download_directory: "{{ ansible_env.HOME }}/linux"
 grsecurity_build_linux_source_directory: >-
   {{ grsecurity_build_download_directory }}/linux-{{ linux_kernel_version }}
 
-grsecurity_build_gpg_keyserver: hkps.pool.sks-keyservers.net
+# Default keyserver for fetching GPG public keys used for verification.
+grsecurity_build_gpg_keyserver: pgp.mit.edu
 
 # Assumes 64-bit (not reading machine architecture dynamically.)
 grsecurity_build_deb_package: >-


### PR DESCRIPTION
The role needs to fetch GPG keys in order to verify signatures on the
downloaded files. The previous default keyserver used an HKPS pool, and
was terribly unreliable: sometimes key lookups would fail with cryptic
messages, then on a subsequent run of the playbook, everything was
happy. That's frustrating, especially in the context of building
kernels, since a kicked off task should run for several hours, and a
failed playbook can waste a lot of time.

Let's fall back to plain and simple pgp.mit.edu. If someone feels
strongly about this choice, it's still a var, so they're welcome to
override it. The new default setting is much more reliable when running
multiple iterations of the config.